### PR TITLE
devices.__getattr__() is not behaving properly

### DIFF
--- a/lib/device.py
+++ b/lib/device.py
@@ -234,13 +234,9 @@ class Device(object):
             return False
         elif attr in self.__dict__:
             return self.__dict__[attr]
-        elif self.__dict__['_init'] and not attr.startswith('__'):
-            try:
-                self.PV(attr)
-                return self.get(attr)
-            except:
-                msg = "Device '%s' has no attribute '%s'"
-                raise AttributeError(msg % (self._prefix, attr))
+        else:
+            raise AttributeError("'{0}' object has no attribute '{1}'"
+                .format(self.__class__.__name__, attr))
 
     def __setattr__(self, attr, val):
         if attr in self.__dict__['_nonpvs']:


### PR DESCRIPTION
`__getattr__()` has to raise AttributeError if lookup fails:

[Python.org](http://docs.python.org/reference/datamodel.html#object.__getattr__)

Called when an attribute lookup has not found the attribute in the usual places (i.e. it is not an instance attribute nor is it found in the class tree for self). name is the attribute name. This method should return the (computed) attribute value or raise an AttributeError exception.
