### PR TITLE
Fixed bug epics.PV where requesting PV.get(count=1, use_monitor=False) raised a TypeError.

### DIFF
--- a/lib/pv.py
+++ b/lib/pv.py
@@ -241,6 +241,9 @@ class PV(object):
         if (as_numpy and ca.HAS_NUMPY and count > 1 and
             not isinstance(val, ca.numpy.ndarray)):
             val = ca.numpy.array(val)
+        elif (as_numpy and ca.HAS_NUMPY and count == 1 and
+            not isinstance(val, ca.numpy.ndarray)):
+            val = ca.numpy.array([val])
         elif (not as_numpy and ca.HAS_NUMPY and
               isinstance(val, ca.numpy.ndarray)):
             val = list(val)


### PR DESCRIPTION
Steps to replicate bug:
import epics
d15 = epics.PV('2idb1:scan1.D15CA')
d15.get(count=1, use_monitor=False)
