### PR TITLE
Fix py3 strings

### DIFF
--- a/lib/ca.py
+++ b/lib/ca.py
@@ -1318,6 +1318,8 @@ def put(chid, value, wait=False, timeout=30, callback=None,
 
     else:
         if ftype == dbr.CHAR and is_string_or_bytes(value):
+            if isinstance(value, bytes):
+                value = value.decode('ascii', 'replace')
             value = [ord(i) for i in ("%s%s" % (value, NULLCHAR))]
         try:
             ndata, nuser = len(data), len(value)

--- a/lib/ca.py
+++ b/lib/ca.py
@@ -1300,12 +1300,14 @@ def put(chid, value, wait=False, timeout=30, callback=None,
     elif nativecount == 1:
         if ftype == dbr.CHAR:
             if is_string_or_bytes(value):
-                value = [ord(i) for i in ("%s%s" % (value, NULLCHAR))]
+                if isinstance(value, bytes):
+                    value = value.decode('ascii', 'replace')
+                value = [ord(i) for i in value] + [0, ]
             else:
                 data[0] = value
         else:
             # allow strings (even bits/hex) to be put to integer types
-            if is_string(value) and isinstance(data[0], (int, long)):
+            if is_string(value) and isinstance(data[0], (int, )):
                 value = int(value, base=0)
             try:
                 data[0] = value
@@ -1320,7 +1322,7 @@ def put(chid, value, wait=False, timeout=30, callback=None,
         if ftype == dbr.CHAR and is_string_or_bytes(value):
             if isinstance(value, bytes):
                 value = value.decode('ascii', 'replace')
-            value = [ord(i) for i in ("%s%s" % (value, NULLCHAR))]
+            value = [ord(i) for i in value] + [0, ]
         try:
             ndata, nuser = len(data), len(value)
             if nuser > ndata:
@@ -1645,8 +1647,11 @@ def sg_put(gid, chid, value):
         # numpy.fromstring(("%s%s" % (s,NULLCHAR*maxlen))[:maxlen],
         #                  dtype=numpy.uint8)
         if ftype == dbr.CHAR and is_string_or_bytes(value):
-            pad = NULLCHAR*(1+count-len(value))
-            value = [ord(i) for i in ("%s%s" % (value, pad))[:count]]
+            pad = [0]*(1+count-len(value))
+            if isinstance(value, bytes):
+                value = value.decode('ascii', 'replace')
+            value = ([ord(i) for i in value] + pad)[:count]
+
         try:
             ndata = len(data)
             nuser = len(value)


### PR DESCRIPTION
Note this is against one of your dev branches, not master.

This should not be merged to master yet as I do not think it is python2 compatible, but I needed this working on a beamline with python3 _now_ so here it is.

The source of the rouge 'b' is that the `str` or `repr` of a byte object in python 3 include the 'b' so that the string formatting `'%s%s' % (value, NULLCHAR)` -> `"b'value_str'b'\\x00"'` which is less than fully helpful.

I suspect that I have done an end-run around some of the stuff it `utils`.  Do you mind picking up a dependency on `six` (which I think would greatly simplify `utils`) or should I re-do this using existing functions (and if so, some direction as to which ones would be appreciated).