### PR TITLE
remove severity check from attach_context() (needed on Darwin?)

### DIFF
--- a/lib/ca.py
+++ b/lib/ca.py
@@ -638,7 +638,7 @@ def destroy_context():
     return context_destroy()
 
 @withCA
-@withSEVCHK
+# @withSEVCHK
 def attach_context(context):
     "attach to the supplied context"
     return libca.ca_attach_context(context)


### PR DESCRIPTION
this removes the Severity Check on attach_context(), which is apparently needed on Darwin.