### PR TITLE
Search for libca.so in EPICS_HOST_ARCH also.

### DIFF
--- a/epics/ca.py
+++ b/epics/ca.py
@@ -159,9 +159,10 @@ def find_libca():
             libname = 'libca.dylib'
 
         epics_base = os.environ.get('EPICS_BASE', '.')
+        epics_host_arch = os.environ.get('EPICS_HOST_ARCH')
         host_arch = os.uname()[0]
         if host_arch in known_hosts:
-            epicspath = []
+            epicspath = [os.path.join(epics_base, 'lib', epics_host_arch)] if epics_host_arch else []
             for adir in known_hosts[host_arch]:
                 epicspath.append(os.path.join(epics_base, 'lib', adir))
         for adir in search_path + epicspath:


### PR DESCRIPTION
We don't use the regular "linux-" prefix, but instead different depending on operating system. E.g. SL6, centos7 and so on. Therefore we depend on that you actually use EPICS_HOST_ARCH.