### PR TITLE
Make get_pv respect the form argument when creating new PVs

### DIFF
--- a/epics/pv.py
+++ b/epics/pv.py
@@ -43,7 +43,7 @@ def get_pv(pvname, form='time',  connect=False,
     start_time = time.time()
     # not cached -- create pv (automaticall saved to cache)
     if thispv is None:
-        thispv = PV(pvname, **kws)
+        thispv = PV(pvname, form=form, **kws)
 
     if connect:
         thispv.wait_for_connection()


### PR DESCRIPTION
The `get_pv` function accepts the `form` parameter but was not using it when creating new PVs. This meant `Device.add_pv` was unable to create PVs with `form='ctrl'` for example. This pull request fixes this by passing in the `form` parameter when instantiating a new PV.