### PR TITLE
Fix: Py3k waveform of strings put()

### DIFF
--- a/epics/ca.py
+++ b/epics/ca.py
@@ -98,7 +98,9 @@ class ChannelAccessException(Exception):
     """Channel Access Exception: General Errors"""
     def __init__(self, *args):
         Exception.__init__(self, *args)
-        sys.excepthook(*sys.exc_info())
+        type_, value, traceback = sys.exc_info()
+        if type_ is not None:
+            sys.excepthook(type_, value, traceback)
 
 class CASeverityException(Exception):
     """Channel Access Severity Check Exception:

--- a/epics/ca.py
+++ b/epics/ca.py
@@ -1305,7 +1305,7 @@ def put(chid, value, wait=False, timeout=30, callback=None,
             data[0].value = value
         else:
             for elem in range(min(count, len(value))):
-                data[elem].value = value[elem]
+                data[elem].value = ascii_string(value[elem])
     elif nativecount == 1:
         if ftype == dbr.CHAR:
             if is_string_or_bytes(value):

--- a/tests/ca_unittest.py
+++ b/tests/ca_unittest.py
@@ -58,17 +58,12 @@ class CA_BasicTests(unittest.TestCase):
     def testA_CreateChid(self):
         write('Simple Test: create chid')
         chid = ca.create_channel(pvnames.double_pv)
-        self.assertIsNot(chid,None)
+        self.assertIsNot(chid, None)
 
     def testA_GetNonExistentPV(self):
         write('Simple Test: get on a non-existent PV')
         chid = ca.create_channel('Definitely-Not-A-Real-PV')
-        val, out = None, False
-        try:
-            val = ca.get(chid)
-        except ca.ChannelAccessException:
-            out = True
-        assert(out)
+        self.assertRaises(ca.ChannelAccessException, ca.get, chid)
 
     def testA_CreateChid_CheckTypeCount(self):
         write('Simple Test: create chid, check count, type, host, and access')
@@ -421,9 +416,9 @@ class CA_BasicTests(unittest.TestCase):
         chid = ca.create_channel(pvnames.double_arrays[0])
         maxpts = ca.element_count(chid)
         npts = int(max(2, maxpts/2.3 - 1))
-        print('max points is', maxpts)
+        write('max points is %s' % (maxpts, ))
         dat = numpy.random.normal(size=npts)
-        print('setting array to a length of npts=', npts)
+        write('setting array to a length of npts=%s' % (npts, ))
         ca.put(chid, dat)
         out1 = ca.get(chid)
         self.assertTrue(isinstance(out1, numpy.ndarray))

--- a/tests/pv_unittest.py
+++ b/tests/pv_unittest.py
@@ -72,7 +72,7 @@ class PV_Tests(unittest.TestCase):
 
             self.failUnless(int(cval)== val)
 
-    def test_stringarray(self):
+    def test_get_string_waveform(self):
         write('String Array: \n')
         with no_simulator_updates():
             pv = PV(pvnames.string_arr_pv)
@@ -82,6 +82,15 @@ class PV_Tests(unittest.TestCase):
             self.failUnless(len(val[0]) > 1)
             self.assertIsInstance(val[1], str)
             self.failUnless(len(val[1]) > 1)
+
+    def test_put_string_waveform(self):
+        write('String Array: \n')
+        with no_simulator_updates():
+            pv = PV(pvnames.string_arr_pv)
+            put_value = ['a', 'b', 'c']
+            pv.put(put_value)
+            get_value = pv.get(use_monitor=False, count=len(put_value))
+            numpy.testing.assert_array_equal(get_value, put_value)
 
     def test_putcomplete(self):
         write('Put with wait and put_complete (using real motor!) \n')

--- a/tests/pv_unittest.py
+++ b/tests/pv_unittest.py
@@ -6,6 +6,7 @@ import sys
 import time
 import unittest
 import numpy
+from contextlib import contextmanager
 from epics import PV, caput, caget, ca
 
 import pvnames
@@ -27,11 +28,15 @@ def onChanges(pvname=None, value=None, **kws):
     global CHANGE_DAT
     CHANGE_DAT[pvname] = value
 
-def pause_updating():
-    caput(pvnames.pause_pv, 1)
+@contextmanager
+def no_simulator_updates():
+    '''Context manager which pauses and resumes simulator PV updating'''
+    try:
+        caput(pvnames.pause_pv, 1)
+        yield
+    finally:
+        caput(pvnames.pause_pv, 0)
 
-def resume_updating():
-    caput(pvnames.pause_pv, 0)
 
 class PV_Tests(unittest.TestCase):
     def testA_CreatePV(self):
@@ -60,26 +65,23 @@ class PV_Tests(unittest.TestCase):
 
     def test_get1(self):
         write('Simple Test: test value and char_value on an integer\n')
-        pause_updating()
-        pv = PV(pvnames.int_pv)
-        val = pv.get()
-        cval = pv.get(as_string=True)
+        with no_simulator_updates():
+            pv = PV(pvnames.int_pv)
+            val = pv.get()
+            cval = pv.get(as_string=True)
 
-        self.failUnless(int(cval)== val)
-        resume_updating()
-
+            self.failUnless(int(cval)== val)
 
     def test_stringarray(self):
         write('String Array: \n')
-        pause_updating()
-        pv = PV(pvnames.string_arr_pv)
-        val = pv.get()
-        self.failUnless(len(val) > 10)
-        self.failUnless(isinstance(val[0], str))
-        self.failUnless(len(val[0]) > 1)
-        self.failUnless(isinstance(val[1], str))
-        self.failUnless(len(val[1]) > 1)
-        resume_updating()
+        with no_simulator_updates():
+            pv = PV(pvnames.string_arr_pv)
+            val = pv.get()
+            self.failUnless(len(val) > 10)
+            self.assertIsInstance(val[0], str)
+            self.failUnless(len(val[0]) > 1)
+            self.assertIsInstance(val[1], str)
+            self.failUnless(len(val[1]) > 1)
 
     def test_putcomplete(self):
         write('Put with wait and put_complete (using real motor!) \n')
@@ -113,7 +115,7 @@ class PV_Tests(unittest.TestCase):
         val = pv.get()
 
         t0 = time.time()
-        if  val < 5:
+        if val < 5:
             pv.put(val + 1.0, wait=True)
         else:
             pv.put(val - 1.0, wait=True)
@@ -265,34 +267,32 @@ class PV_Tests(unittest.TestCase):
         pvlist = (pvnames.char_arr_pv,
                   pvnames.long_arr_pv,
                   pvnames.double_arr_pv)
-        pause_updating()
-        chids = []
-        for name in pvlist:
-            chid = ca.create_channel(name)
-            ca.connect_channel(chid)
-            chids.append((chid, name))
-            ca.poll(evt=0.025, iot=5.0)
-        ca.poll(evt=0.05, iot=10.0)
+        with no_simulator_updates():
+            chids = []
+            for name in pvlist:
+                chid = ca.create_channel(name)
+                ca.connect_channel(chid)
+                chids.append((chid, name))
+                ca.poll(evt=0.025, iot=5.0)
+            ca.poll(evt=0.05, iot=10.0)
 
-        values = {}
-        for chid, name in chids:
-            values[name] = ca.get(chid)
-        for promotion in ('ctrl', 'time'):
-            for chid, pvname in chids:
-                write('=== %s  chid=%s as %s\n' % (ca.name(chid),
-                                                   repr(chid), promotion))
-                time.sleep(0.01)
-                if promotion == 'ctrl':
-                    ntype = ca.promote_type(chid, use_ctrl=True)
-                else:
-                    ntype = ca.promote_type(chid, use_time=True)
+            values = {}
+            for chid, name in chids:
+                values[name] = ca.get(chid)
+            for promotion in ('ctrl', 'time'):
+                for chid, pvname in chids:
+                    write('=== %s  chid=%s as %s\n' % (ca.name(chid),
+                                                       repr(chid), promotion))
+                    time.sleep(0.01)
+                    if promotion == 'ctrl':
+                        ntype = ca.promote_type(chid, use_ctrl=True)
+                    else:
+                        ntype = ca.promote_type(chid, use_time=True)
 
-                val  = ca.get(chid, ftype=ntype)
-                cval = ca.get(chid, as_string=True)
-                for a, b in zip(val, values[pvname]):
-                    self.assertEqual(a, b)
-
-        resume_updating()
+                    val  = ca.get(chid, ftype=ntype)
+                    cval = ca.get(chid, as_string=True)
+                    for a, b in zip(val, values[pvname]):
+                        self.assertEqual(a, b)
 
     def test_waveform_get_1elem(self):
         pv = PV(pvnames.double_arr_pv)


### PR DESCRIPTION
* Fixes waveform of strings `put()` in Python 3, added a unit test for it. It was just a missing a call to `ascii_string`. 
* Adds a context manager to pause simulator updating for the tests. I found that if one test failed it might affect the others, as simulator updating was never resumed
* All tests are passing now in 2.7/3.4 (minus the 'real motor' one which I don't have an IOC for - I added a skiptest for this in my other PR #49).