### PR TITLE
Fix scalar len and zero-length strings

### DIFF
--- a/epics/ca.py
+++ b/epics/ca.py
@@ -1031,13 +1031,15 @@ def _unpack(chid, data, count=None, ftype=None, as_numpy=True):
             else:
                 out = numpy.ctypeslib.as_array(memcopy(data))
         else:
-            out = memcopy(data)
+            out = list(data)
         return out
 
-    def unpack(data, count, ntype, use_numpy):
+    def unpack(data, count, ntype, use_numpy, elem_count):
         "simple, native data type"
         if data is None:
             return None
+        elif ntype == dbr.CHAR and elem_count > 1:
+            return array_cast(data, count, ntype, use_numpy)
         elif count == 1 and ntype != dbr.STRING:
             return data[0]
         elif ntype == dbr.STRING:
@@ -1062,8 +1064,11 @@ def _unpack(chid, data, count=None, ftype=None, as_numpy=True):
     if ftype is None:
         ftype = dbr.INT
     ntype = native_type(ftype)
-    use_numpy = (HAS_NUMPY and as_numpy and ntype != dbr.STRING and count != 1)
-    return unpack(data, count, ntype, use_numpy)
+    elem_count = element_count(chid)
+    numpy_count = (count != 1 and elem_count > 1)
+    use_numpy = (HAS_NUMPY and as_numpy and ntype != dbr.STRING and
+                 numpy_count)
+    return unpack(data, count, ntype, use_numpy, elem_count)
 
 @withConnectedCHID
 def get(chid, ftype=None, count=None, wait=True, timeout=None,

--- a/epics/pv.py
+++ b/epics/pv.py
@@ -294,7 +294,12 @@ class PV(object):
             return val
 
         if count is None:
-            count = len(val)
+            try:
+                count = len(val)
+            except TypeError:
+                # not an array-type, just return the value itself
+                return val
+
         if (as_numpy and ca.HAS_NUMPY and
             not isinstance(val, ca.numpy.ndarray)):
             if count == 1:
@@ -373,9 +378,13 @@ class PV(object):
             self._args['char_value'] = cval
             return cval
 
-        cval  = repr(val)
+        cval = repr(val)
         if self.count > 1:
-            cval = '<array size=%d, type=%s>' % (len(val),
+            try:
+                array_size = len(val)
+            except TypeError:
+                array_size = None
+            cval = '<array size=%s, type=%s>' % (array_size,
                                                  dbr.Name(ftype).lower())
         elif ntype in (dbr.FLOAT, dbr.DOUBLE):
             if call_ca and self._args['precision'] is None:

--- a/epics/pv.py
+++ b/epics/pv.py
@@ -28,7 +28,7 @@ def get_pv(pvname, form='time',  connect=False,
     context   PV threading context (default None)
     timeout   connection timeout, in seconds (default 5.0)
     """
-    
+
     if form not in ('native', 'time', 'ctrl'):
         form = 'native'
 
@@ -39,7 +39,7 @@ def get_pv(pvname, form='time',  connect=False,
             context = ca.current_context()
         if (pvname, form, context) in _PVcache_:
             thispv = _PVcache_[(pvname, form, context)]
-    
+
     start_time = time.time()
     # not cached -- create pv (automaticall saved to cache)
     if thispv is None:
@@ -151,7 +151,7 @@ class PV(object):
             chid = chid.value
         self._args['chid'] = self.chid = chid
         self.__on_connect(pvname=pvname, chid=chid, conn=conn, **kws)
-        
+
     def __on_connect(self, pvname=None, chid=None, conn=True):
         "callback for connection events"
         # occassionally chid is still None (ie if a second PV is created
@@ -295,7 +295,7 @@ class PV(object):
 
         if count is None:
             count = len(val)
-        if (as_numpy and ca.HAS_NUMPY and 
+        if (as_numpy and ca.HAS_NUMPY and
             not isinstance(val, ca.numpy.ndarray)):
             if count == 1:
                 val = [val]
@@ -357,9 +357,11 @@ class PV(object):
         if ntype == dbr.CHAR and self.count < ca.AUTOMONITOR_MAXLENGTH:
             if isinstance(val, ca.numpy.ndarray):
                 val = val.tolist()
-            elif self.count==1: # handles single character in waveform
+            elif self.count==1 or isinstance(val, int):
+                # single character in waveform
                 val = [val]
-            val = list(val)
+            else:
+                val = list(val)
             if 0 in val:
                 firstnull  = val.index(0)
             else:
@@ -370,7 +372,7 @@ class PV(object):
                 cval = ''
             self._args['char_value'] = cval
             return cval
-        
+
         cval  = repr(val)
         if self.count > 1:
             cval = '<array size=%d, type=%s>' % (len(val),
@@ -404,7 +406,7 @@ class PV(object):
         kwds = ca.get_ctrlvars(self.chid, timeout=timeout, warn=warn)
         self._args.update(kwds)
         return kwds
-        
+
     def get_timevars(self, timeout=5, warn=True):
         "get time values for variable"
         if not self.wait_for_connection():

--- a/tests/ca_unittest.py
+++ b/tests/ca_unittest.py
@@ -395,7 +395,7 @@ class CA_BasicTests(unittest.TestCase):
         self.assertTrue(isinstance(aval, numpy.ndarray))
         self.assertTrue(len(aval) > 2)
 
-        self.assertTrue(isinstance(cval, ctypes.Array))
+        self.assertTrue(isinstance(cval, list))
         self.assertTrue(len(cval) > 2)
         lval = list(cval)
         self.assertTrue(isinstance(lval, list))

--- a/tests/pv_unittest.py
+++ b/tests/pv_unittest.py
@@ -233,6 +233,24 @@ class PV_Tests(unittest.TestCase):
         self.assertEqual(len(subval), 5)
         self.failUnless(numpy.all(subval == full_data[13:5+13]))
 
+    def test_subarray_zerolen_no_monitor(self):
+        # a test of a char waveform of length 1 (NORD=1): value "\0"
+        # without using autom_onitor
+        zerostr = PV(pvnames.char_arr_zeroish_length_pv, auto_monitor=False)
+        zerostr.wait_for_connection()
+
+        self.assertEquals(zerostr.get(as_string=True), '')
+        self.assertEquals(zerostr.get(as_string=False), 0)
+
+    def test_subarray_zerolen_monitor(self):
+        # a test of a char waveform of length 1 (NORD=1): value "\0"
+        # with using auto_monitor
+        zerostr = PV(pvnames.char_arr_zeroish_length_pv, auto_monitor=True)
+        zerostr.wait_for_connection()
+
+        self.assertEquals(zerostr.get(as_string=True), '')
+        self.assertEquals(zerostr.get(as_string=False), 0)
+
     def test_subarray_zerolen(self):
         subarr1 = PV(pvnames.zero_len_subarr1)
         subarr1.wait_for_connection()

--- a/tests/pv_unittest.py
+++ b/tests/pv_unittest.py
@@ -240,7 +240,7 @@ class PV_Tests(unittest.TestCase):
         zerostr.wait_for_connection()
 
         self.assertEquals(zerostr.get(as_string=True), '')
-        self.assertEquals(zerostr.get(as_string=False), 0)
+        numpy.testing.assert_array_equal(zerostr.get(as_string=False), [0])
 
     def test_subarray_zerolen_monitor(self):
         # a test of a char waveform of length 1 (NORD=1): value "\0"
@@ -249,7 +249,7 @@ class PV_Tests(unittest.TestCase):
         zerostr.wait_for_connection()
 
         self.assertEquals(zerostr.get(as_string=True), '')
-        self.assertEquals(zerostr.get(as_string=False), 0)
+        numpy.testing.assert_array_equal(zerostr.get(as_string=False), [0])
 
     def test_subarray_zerolen(self):
         subarr1 = PV(pvnames.zero_len_subarr1)

--- a/tests/pvnames.py
+++ b/tests/pvnames.py
@@ -34,6 +34,7 @@ double_arr_pv = 'Py:double2k'
 string_arr_pv = 'Py:string128'
 # char / byte array
 char_arr_pv   = 'Py:char128'
+char_arr_zeroish_length_pv = 'Py:waveform_char256'
 char_arrays   = ['Py:char128', 'Py:char2k', 'Py:char64k']
 long_arrays   = ['Py:long128', 'Py:long2k', 'Py:long64k']
 double_arrays   = ['Py:double128', 'Py:double2k', 'Py:double64k']


### PR DESCRIPTION
I ran into further issues with zero-length strings and some scalar-value related oddities. Here are two small fixes: both should be minor enough as to not break anything else. Added 2 tests for these. Cousin PR is pyepics/testioc#3.

Example PV:
```sh
$ caget -Sc 'XF:31IDA-BI{Cam:Tbl}cam1:StringFromServer_RBV'
XF:31IDA-BI{Cam:Tbl}cam1:StringFromServer_RBV 0
```

Case 1 that was failing (non-automonitored waveform char as string):
```python
In [1]: epics.PV('XF:31IDA-BI{Cam:Tbl}cam1:StringFromServer_RBV', auto_monitor=False).get(as_string=True)

pyepics/epics/pv.py in get(self, count, as_string, as_numpy, timeout, with_ctrlvars, use_monitor)
    290         val = self._args['value']
    291         if as_string:
--> 292             return self._set_charval(val)
    293         if self.count <= 1 or val is None:
    294             return val

pyepics/epics/pv.py in _set_charval(self, val, call_ca)
    360             elif self.count==1: # handles single character in waveform
    361                 val = [val]
--> 362             val = list(val)
    363             if 0 in val:
    364                 firstnull  = val.index(0)

TypeError: 'int' object is not iterable
```

Case 2:
```python
In [2]: epics.PV('XF:31IDA-BI{Cam:Tbl}cam1:StringFromServer_RBV', auto_monitor=False).get()

pyepics/epics/pv.py in get(self, count, as_string, as_numpy, timeout, with_ctrlvars, use_monitor)
    295
    296         if count is None:
--> 297             count = len(val)
    298         if (as_numpy and ca.HAS_NUMPY and
    299             not isinstance(val, ca.numpy.ndarray)):

TypeError: object of type 'int' has no len()
```

With this PR:
```python
In [1]: epics.PV('XF:31IDA-BI{Cam:Tbl}cam1:StringFromServer_RBV', auto_monitor=False).get()
Out[1]: 0

In [2]: epics.PV('XF:31IDA-BI{Cam:Tbl}cam1:StringFromServer_RBV', auto_monitor=False).get(as_string=True)
Out[2]: ''

```