### PR TITLE
API: If precision is not given, return None, not 0.

### DIFF
--- a/epics/ca.py
+++ b/epics/ca.py
@@ -1488,8 +1488,8 @@ def get_precision(chid):
     """return the precision of a Channel.  For Channels with
     native type other than FLOAT or DOUBLE, this will be 0"""
     if field_type(chid) in (dbr.FLOAT, dbr.DOUBLE):
-        return get_ctrlvars(chid).get('precision', 0)
-    return 0
+        return get_ctrlvars(chid).get('precision', None)
+    return None
 
 def get_enum_strings(chid):
     """return list of names for ENUM states of a Channel.  Returns


### PR DESCRIPTION
@newville Would you be open to this change? Downstream, we'd like to display 3 decimal places by default when precision is not defined by EPICS. But pyepics currently doesn't provide enough information for us to know whether precision is undefined or actually 0.

cc @dchabot You and I [had the same thought](https://github.com/NSLS-II/ophyd/pull/284#issuecomment-191796313).