### PR TITLE
Add travis configuration for CI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,90 @@
+language: python
+
+sudo: required
+dist: trusty
+
+services:
+  - docker
+
+cache:
+  directories:
+    - $HOME/.cache/pip
+
+matrix:
+  include:
+  # - python: 2.7
+    - python: 3.4
+  # - python: 3.5
+
+before_install:
+  - export DOCKER0_IP=$(/sbin/ifconfig docker0 |grep 'inet addr' | sed -e 's/.*addr:\([^ ]*\).*/\1/')
+  - export EPICS_CA_ADDR_LIST=$( echo $DOCKER0_IP | sed -e 's/^\([0-9]\+\)\.\([0-9]\+\)\..*$/\1.\2.255.255/' )
+  - export EPICS_CA_AUTO_ADDR_LIST="no"
+  - export EPICS_CA_MAX_ARRAY_BYTES=10000000
+  - export DOCKERIMAGE="klauer/simioc-docker"
+  - export DOCKERTAG="pyepics-docker"
+  - export CONDA_ENV="testenv"
+
+  - perl --version
+  - git fetch --unshallow
+  - docker pull ${DOCKERIMAGE}:${DOCKERTAG}
+  - docker images
+  - docker ps -a
+  - docker run -d -p $DOCKER0_IP:5064:5064/tcp -p $DOCKER0_IP:5065:5065/udp --name epics_iocs ${DOCKERIMAGE}:${DOCKERTAG}
+  - docker ps -a
+
+  # INSTALL CONDA
+  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+  - chmod +x miniconda.sh
+  - "./miniconda.sh -b -p /home/travis/mc"
+  - env
+
+  - export PATH=/home/travis/mc/bin:$PATH
+  - conda config --set always_yes true
+  - conda update conda --yes
+  - conda install conda-build anaconda-client jinja2
+  - conda config --add channels lightsource2
+  - conda config --add channels soft-matter
+
+  # MAKE THE CONDA RECIPE
+  - conda create -n $CONDA_ENV python=$TRAVIS_PYTHON_VERSION epics-base
+  - source activate $CONDA_ENV
+
+  # need to reactivate after installing epics-base so that the EPICS_BASE env
+  # var is set
+  - source activate $CONDA_ENV
+
+install:
+  # install pyepics dependencies
+  - conda install numpy
+  - pip install coveralls pytest pytest-cov
+  # install pyepics as a source install
+  - python setup.py develop
+
+  # setup some path environment variables for epics
+  - export PATH=$PATH:$EPICS_BASE/bin/$EPICS_HOST_ARCH
+  - export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$EPICS_BASE/lib/$EPICS_HOST_ARCH"
+  - echo "PATH=$PATH"
+
+script:
+  # check/record some basic pyepics things
+  - echo "Checking pyepics version and libca locations:"
+  - python -c "import epics; print(epics.__version__)"
+  - python -c "import epics.ca; print(epics.ca.find_libca())"
+
+  - echo "Checking if the motor/areadetector IOC is running:"
+  - python -c "import epics; print('mtr1', epics.caget('sim:mtr1.RBV'))"
+  - python -c "import epics; print('arraycounter', epics.caget('sim:det:ROI1:ArrayCounter'))"
+  - echo "Checking if the pyepics test suite ioc is running:"
+  - python -c "import epics; print('long1', epics.caget('Py:long1'))"
+
+  - caget sim:mtr1.RBV
+  - caget sim:det:ROI1:ArrayCounter
+  - caget Py:long1
+
+  # running tests
+  - py.test -vv --cov=epics --cov-report term-missing tests/ca_unittest.py tests/pv_unittest.py
+
+after_success:
+    - env
+    - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ cache:
 
 matrix:
   include:
-  # - python: 2.7
+    - python: 2.7
     - python: 3.4
-  # - python: 3.5
+    - python: 3.5
 
 before_install:
   - export DOCKER0_IP=$(/sbin/ifconfig docker0 |grep 'inet addr' | sed -e 's/.*addr:\([^ ]*\).*/\1/')

--- a/tests/pv_unittest.py
+++ b/tests/pv_unittest.py
@@ -257,8 +257,6 @@ class PV_Tests(unittest.TestCase):
 
             # elem_count = 128, requested count = None, libca returns count = 1
             zerostr.put([0], wait=True)
-            time.sleep(0.2)
-
             self.assertEquals(zerostr.get(as_string=True), '')
             numpy.testing.assert_array_equal(zerostr.get(as_string=False), [0])
             self.assertEquals(zerostr.get(as_string=True, as_numpy=False), '')
@@ -266,8 +264,6 @@ class PV_Tests(unittest.TestCase):
 
             # elem_count = 128, requested count = None, libca returns count = 2
             zerostr.put([0, 0], wait=True)
-            time.sleep(0.2)
-
             self.assertEquals(zerostr.get(as_string=True), '')
             numpy.testing.assert_array_equal(zerostr.get(as_string=False), [0, 0])
             self.assertEquals(zerostr.get(as_string=True, as_numpy=False), '')
@@ -282,12 +278,16 @@ class PV_Tests(unittest.TestCase):
             zerostr.wait_for_connection()
 
             zerostr.put([0], wait=True)
+            time.sleep(0.2)
+
             self.assertEquals(zerostr.get(as_string=True), '')
             numpy.testing.assert_array_equal(zerostr.get(as_string=False), [0])
             self.assertEquals(zerostr.get(as_string=True, as_numpy=False), '')
             numpy.testing.assert_array_equal(zerostr.get(as_string=False, as_numpy=False), [0])
 
             zerostr.put([0, 0], wait=True)
+            time.sleep(0.2)
+
             self.assertEquals(zerostr.get(as_string=True), '')
             numpy.testing.assert_array_equal(zerostr.get(as_string=False), [0, 0])
             self.assertEquals(zerostr.get(as_string=True, as_numpy=False), '')

--- a/tests/pvnames.py
+++ b/tests/pvnames.py
@@ -42,8 +42,7 @@ double_arrays   = ['Py:double128', 'Py:double2k', 'Py:double64k']
 ####
 # provide a single motor prefix (to which '.VAL' and '.RBV' etc will be added)
 
-motor_prefix = '13XRM:'
-motor_list = ['%sm%i' % (motor_prefix, i+1) for i in range(4)]
+motor_list = ['sim:mtr%d' % i for i in range(1, 7)]
 motor1 = motor_list[0]
 motor2 = motor_list[1]
 


### PR DESCRIPTION
This adds preliminary continuous integration testing via a docker image that runs an EPICS IOC with a simulated area detector, simulated motors, and the pyepics testioc records.

That docker image is currently external, but it should probably be brought into the pyepics organization: 
* [github repo](https://github.com/klauer/simioc-docker/tree/pyepics-docker) (where the Dockerfile is located that generates the docker image)
* [docker hub](https://hub.docker.com/r/klauer/simioc-docker/) (where the docker image is stored)

Here's what a passing build looks like: https://travis-ci.org/klauer/pyepics/builds/121256923

~~TODO: change the currently-skipped tests which reference real motors to use simulated motors~~