### PR TITLE
Fix bug in PV._set_charval when numpy is not installed

### DIFF
--- a/epics/pv.py
+++ b/epics/pv.py
@@ -360,7 +360,7 @@ class PV(object):
             return val
         # char waveform as string
         if ntype == dbr.CHAR and self.count < ca.AUTOMONITOR_MAXLENGTH:
-            if isinstance(val, ca.numpy.ndarray):
+            if ca.HAS_NUMPY and isinstance(val, ca.numpy.ndarray):
                 # a numpy array
                 val = val.tolist()
 


### PR DESCRIPTION
When the PV class goes to generate the `char_value` for a char waveform it checks whether the value is a numpy `ndarray` and if so converts it to a list. This check was producing an `AttributeError` if numpy was not installed and thus failing to set `char_value`. This change makes `_set_charval` first check if numpy is available before doing the`isinstance` check.