### PR TITLE
FIX: python 3 atexit cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,14 @@ install:
   - export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$EPICS_BASE/lib/$EPICS_HOST_ARCH"
   - echo "PATH=$PATH"
 
+  # allow gdb backtrace to show when tests fail
+  - sudo apt-get -y install gdb
+  - ulimit -c
+
+before_script:
+  # ref: github.com/springmeyer/travis-coredump
+  - ulimit -c unlimited -S
+
 script:
   # check/record some basic pyepics things
   - echo "Checking pyepics version and libca locations:"
@@ -83,7 +91,9 @@ script:
   - caget Py:long1
 
   # running tests
-  - py.test -vv --cov=epics --cov-report term-missing tests/ca_unittest.py tests/pv_unittest.py
+  - py.test -vv --cov=epics --cov-report term-missing tests/ca_unittest.py tests/pv_unittest.py  || RESULT=$?
+  - if [[ ${RESULT} != 0 ]]; then gdb python core* -ex "thread apply all bt" -ex "set pagination 0" -batch; fi
+  - if [[ ${RESULT} != 0 ]]; then exit $RESULT ; fi;
 
 after_success:
     - env

--- a/epics/ca.py
+++ b/epics/ca.py
@@ -60,7 +60,7 @@ error_message = ''
 ## PREEMPTIVE_CALLBACK determines the CA context
 PREEMPTIVE_CALLBACK = True
 
-AUTO_CLEANUP = (sys.version_info.major == 2)
+AUTO_CLEANUP = True
 
 ##
 # maximum element count for auto-monitoring of PVs in epics.pv
@@ -263,8 +263,13 @@ def finalize_libca(maxtime=10.0):
         flush_io()
         poll()
         for ctx in _cache.values():
-            for key in list(ctx.keys()):
-                ctx.pop(key)
+            for key, info in ctx.items():
+                try:
+                    clear_channel(info['chid'])
+                except KeyError:
+                    pass
+            ctx.clear()
+
         _cache.clear()
         flush_count = 0
         while (flush_count < 5 and

--- a/epics/ca.py
+++ b/epics/ca.py
@@ -262,14 +262,13 @@ def finalize_libca(maxtime=10.0):
         start_time = time.time()
         flush_io()
         poll()
-        for ctx in _cache.values():
-            for key, info in ctx.items():
+        for ctxid, ctx in _cache.items():
+            for pvname, info in ctx.items():
                 try:
                     clear_channel(info['chid'])
                 except KeyError:
                     pass
             ctx.clear()
-
         _cache.clear()
         flush_count = 0
         while (flush_count < 5 and
@@ -647,8 +646,7 @@ def context_destroy():
     ctx = current_context()
     ret = libca.ca_context_destroy()
     if ctx in _cache:
-        for key in list(_cache[ctx].keys()):
-            _cache[ctx].pop(key)
+        _cache[ctx].clear()
         _cache.pop(ctx)
     return ret
 

--- a/epics/pv.py
+++ b/epics/pv.py
@@ -769,9 +769,10 @@ class PV(object):
 
         if self._monref is not None:
             cback, uarg, evid = self._monref
-            ca.clear_subscription(evid)
             ctx = ca.current_context()
             if self.pvname in ca._cache[ctx]:
+                # atexit may have already cleared the subscription
+                ca.clear_subscription(evid)
                 ca._cache[ctx].pop(self.pvname)
             del cback
             del uarg


### PR DESCRIPTION
I ~~think~~ hope this will finally resolve the crashes we've seen both locally and on travis.

This PR adds:
* atexit cleanup: `clear_channel` called on all PVs in the cache
* checks to make sure `PV.disconnect` doesn't call `clear_subscription` after the atexit code is called
* automatic gdb backtrace shown if py.test still segfaults (see 3.4 or 3.5 [here](https://travis-ci.org/klauer/pyepics/jobs/124517278) for an example)

Side-note: we need some multi-context tests to consider them supported