### PR TITLE
FIX/CLN: context-related tweaks and basic threading tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,7 +91,7 @@ script:
   - caget Py:long1
 
   # running tests
-  - py.test -vv --cov=epics --cov-report term-missing tests/ca_unittest.py tests/pv_unittest.py  || RESULT=$?
+  - py.test -vv --cov=epics --cov-report term-missing tests/ca_unittest.py tests/pv_unittest.py tests/test_pool.py || RESULT=$?
   - if [[ ${RESULT} != 0 ]]; then gdb python core* -ex "thread apply all bt" -ex "set pagination 0" -batch; fi
   - if [[ ${RESULT} != 0 ]]; then exit $RESULT ; fi;
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,7 +91,7 @@ script:
   - caget Py:long1
 
   # running tests
-  - py.test -vv --cov=epics --cov-report term-missing tests/ca_unittest.py tests/pv_unittest.py tests/test_pool.py || RESULT=$?
+  - py.test -vv --cov=epics --cov-report term-missing tests/ca_unittest.py tests/pv_unittest.py tests/test_pool.py tests/test_threading.py || RESULT=$?
   - if [[ ${RESULT} != 0 ]]; then gdb python core* -ex "thread apply all bt" -ex "set pagination 0" -batch; fi
   - if [[ ${RESULT} != 0 ]]; then exit $RESULT ; fi;
 

--- a/epics/ca.py
+++ b/epics/ca.py
@@ -1700,8 +1700,5 @@ class CAThread(Thread):
     initial CA context is used.
     """
     def run(self):
-        if sys.platform == 'darwin':
-            create_context()
-        else:
-            use_initial_context()
+        use_initial_context()
         Thread.run(self)

--- a/epics/multiproc.py
+++ b/epics/multiproc.py
@@ -17,6 +17,7 @@ Channel Access or using Epics process variables
 
 import multiprocessing as mp
 from multiprocessing.pool import Pool
+from . import ca
 from .ca import clear_cache
 
 
@@ -33,6 +34,7 @@ class CAProcess(mp.Process):
         mp.Process.__init__(self, **kws)
 
     def run(self):
+        ca.initial_context = None
         clear_cache()
         mp.Process.run(self)
 

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -14,7 +14,6 @@ def pool_ctx():
     pool.close()
     pool.join()
 
-
 def test_caget():
     with pool_ctx() as pool:
         print('Using caget() in subprocess pools:')
@@ -43,16 +42,3 @@ def test_manager():
                    for pv in PVS]
 
     print('\tResulting pv dictionary: %s' % pv_dict)
-
-
-def main():
-    print('Initializing ca context in main process...')
-    value = epics.caget(PVS[0])
-    print('\t%s = %s' % (PVS[0], value))
-
-    caget_test()
-    manager_test()
-
-
-if __name__ == '__main__':
-    main()

--- a/tests/test_threading.py
+++ b/tests/test_threading.py
@@ -1,0 +1,71 @@
+import epics
+import threading
+import pvnames
+
+
+def test_basic_thread():
+    result = []
+    def thread():
+        epics.ca.use_initial_context()
+        pv = epics.PV(pvnames.double_pv)
+        result.append(pv.get())
+
+    epics.ca.use_initial_context()
+    t = threading.Thread(target=thread)
+    t.start()
+    t.join()
+
+    assert len(result) and result[0] is not None
+
+
+def test_basic_cathread():
+    result = []
+    def thread():
+        pv = epics.PV(pvnames.double_pv)
+        result.append(pv.get())
+
+    epics.ca.use_initial_context()
+    t = epics.ca.CAThread(target=thread)
+    t.start()
+    t.join()
+
+    assert len(result) and result[0] is not None
+
+
+def test_attach_context():
+    result = []
+    def thread():
+        epics.ca.create_context()
+        pv = epics.PV(pvnames.double_pv2)
+        assert pv.wait_for_connection()
+        result.append(pv.get())
+        epics.ca.detach_context()
+
+        epics.ca.attach_context(ctx)
+        pv = epics.PV(pvnames.double_pv)
+        assert pv.wait_for_connection()
+        result.append(pv.get())
+
+    epics.ca.use_initial_context()
+    ctx = epics.ca.current_context()
+    t = threading.Thread(target=thread)
+    t.start()
+    t.join()
+
+    assert len(result) == 2 and result[0] is not None
+    print(result)
+
+
+def test_pv_from_main():
+    result = []
+    def thread():
+        result.append(pv.get())
+
+    epics.ca.use_initial_context()
+    pv = epics.PV(pvnames.double_pv2)
+
+    t = epics.ca.CAThread(target=thread)
+    t.start()
+    t.join()
+
+    assert len(result) and result[0] is not None


### PR DESCRIPTION
* Adds some basic context creation and `CAThread` tests
* Cleaned up `CAPool` tests for multiprocessing - they are now run automatically in py.test
* Confirmed that darwin check is now unnecessary in `CAThread`

Working on OSX locally, and passing on travis.

Closes #37 (not directly, but because the tests are passing on OSX)
Closes #15 (multiprocessing tests now work fine with the same code on OSX/Linux)