### PR TITLE
Highprecision timestamps

### DIFF
--- a/doc/ca.rst
+++ b/doc/ca.rst
@@ -569,6 +569,8 @@ the callback function may also include some of these as keyword arguments:
     * `units`:  string for PV units
     * `severity`: PV severity
     * `timestamp`: timestamp from CA server.
+    * `seconds`: integer seconds of timestamp from CA server.
+    * `nanoseconds`: integer nanoseconds of timestamp from CA server.
 
 Note that a the user-supplied callback will be run *inside* a CA function,
 and cannot reliably make any other CA calls.  It is helpful to think "this

--- a/doc/ca.rst
+++ b/doc/ca.rst
@@ -569,7 +569,7 @@ the callback function may also include some of these as keyword arguments:
     * `units`:  string for PV units
     * `severity`: PV severity
     * `timestamp`: timestamp from CA server.
-    * `seconds`: integer seconds of timestamp from CA server.
+    * `posixseconds`: integer seconds since POSIX epoch of timestamp from CA server.
     * `nanoseconds`: integer nanoseconds of timestamp from CA server.
 
 Note that a the user-supplied callback will be run *inside* a CA function,

--- a/doc/pv.rst
+++ b/doc/pv.rst
@@ -321,23 +321,28 @@ assigned to.  The exception to this rule is the :attr:`value` attribute.
 
 .. attribute:: timestamp
 
-   Unix (not Epics!!) timestamp of the last seen event for this PV.  Note
-   that this is will contain the timestamp from the Epics record if the PV
-   object was created with the ``form='time'`` option.  Otherwise, the
-   timestamp will be the timestamp according to the client, indicating when
-   the data arrive from the server.
+   floating point timestamp (relative to the POSIX time origin, not the
+   EPICS time origin) of the last event seen for this PV.  Note that this
+   is will contain the timestamp from the Epics server if the PV object was
+   created with the ``form='time'`` option.  Otherwise, the timestamp will
+   be set to time according to the client, indicating when the data arrive
+   from the server.
 
-.. attribute:: seconds
+.. attribute:: posixseconds
 
-   Integer part of the Epics (not Unix!!) timestamp of the last seen event
-   for this PV.   This will only be set if the PV object was created with
-   the ``form='time'`` option.  
+   Integer number of seconds (relative to the POSIX time origin, not the
+   EPICS time origin) of the last event seen for this PV.  This will be set
+   only if the PV object was created with the ``form='time'`` option, and
+   will reflect the timestamp from the server.  Otherwise, this value will
+   be 0 which can be used to signal that the `timestamp` attribute is from
+   the client.
 
 .. attribute:: nanoseconds
 
-   Integer number of nanoseconds of the Epics (not Unix!!) timestamp of the
-   last seen event for this PV.  This will only be set if the PV object was
-   created with the ``form='time'`` option.
+   Integer number of nanoseconds for the last event seen for ths PV.  This
+   will be set only if the PV object was created with the ``form='time'``
+   option, and will give higher time resolution than the `timestamp`
+   attribute.
 
 .. attribute:: precision
 

--- a/doc/pv.rst
+++ b/doc/pv.rst
@@ -327,6 +327,18 @@ assigned to.  The exception to this rule is the :attr:`value` attribute.
    timestamp will be the timestamp according to the client, indicating when
    the data arrive from the server.
 
+.. attribute:: seconds
+
+   Integer part of the Epics (not Unix!!) timestamp of the last seen event
+   for this PV.   This will only be set if the PV object was created with
+   the ``form='time'`` option.  
+
+.. attribute:: nanoseconds
+
+   Integer number of nanoseconds of the Epics (not Unix!!) timestamp of the
+   last seen event for this PV.  This will only be set if the PV object was
+   created with the ``form='time'`` option.
+
 .. attribute:: precision
 
    number of decimal places of precision to use for float and double PVs

--- a/epics/ca.py
+++ b/epics/ca.py
@@ -509,8 +509,8 @@ def _onMonitorEvent(args):
             kwds['status']    = tmpv.status
             kwds['severity']  = tmpv.severity
             kwds['timestamp'] = dbr.make_unixtime(tmpv.stamp)
-            kwds['seconds']   =  tmpv.stamp.secs
-            kwds['nanoseconds'] =  tmpv.stamp.nsec
+            kwds['posixseconds'] = tmpv.stamp.secs + dbr.EPICS2UNIX_EPOCH
+            kwds['nanoseconds'] = tmpv.stamp.nsec
         except IndexError:
             pass
 

--- a/epics/ca.py
+++ b/epics/ca.py
@@ -509,6 +509,8 @@ def _onMonitorEvent(args):
             kwds['status']    = tmpv.status
             kwds['severity']  = tmpv.severity
             kwds['timestamp'] = dbr.make_unixtime(tmpv.stamp)
+            kwds['seconds']   =  tmpv.stamp.secs
+            kwds['nanoseconds'] =  tmpv.stamp.nsec
         except IndexError:
             pass
 

--- a/epics/pv.py
+++ b/epics/pv.py
@@ -89,7 +89,7 @@ class PV(object):
     _fmtarr = "<PV '%(pvname)s', count=%(count)i/%(nelm)i, type=%(typefull)s, access=%(access)s>"
     _fields = ('pvname',  'value',  'char_value',  'status',  'ftype',  'chid',
                'host', 'count', 'access', 'write_access', 'read_access',
-               'severity', 'timestamp', 'seconds', 'nanoseconds',
+               'severity', 'timestamp', 'posixseconds', 'nanoseconds',
                'precision', 'units', 'enum_strs',
                'upper_disp_limit', 'lower_disp_limit', 'upper_alarm_limit',
                'lower_alarm_limit', 'lower_warning_limit',
@@ -443,7 +443,7 @@ class PV(object):
         self._args.update(kwd)
         self._args['value']  = value
         self._args['timestamp'] = kwd.get('timestamp', time.time())
-        self._args['seconds'] = kwd.get('seconds', 0)
+        self._args['posixseconds'] = kwd.get('posixseconds', 0)
         self._args['nanoseconds'] = kwd.get('nanoseconds', 0)
         self._set_charval(self._args['value'], call_ca=False)
         if self.verbose:
@@ -551,7 +551,7 @@ class PV(object):
         for nam in ('char_value', 'count', 'nelm', 'type', 'units',
                     'precision', 'host', 'access',
                     'status', 'severity', 'timestamp',
-                    'seconds', 'nanoseconds',
+                    'posixseconds', 'nanoseconds',
                     'upper_ctrl_limit', 'lower_ctrl_limit',
                     'upper_disp_limit', 'lower_disp_limit',
                     'upper_alarm_limit', 'lower_alarm_limit',
@@ -592,7 +592,7 @@ class PV(object):
             self.get()
         if self._args[arg] is None:
             if arg in ('status', 'severity', 'timestamp',
-                       'seconds', 'nanoseconds'):
+                       'posixseconds', 'nanoseconds'):
                 self.get_timevars(timeout=1, warn=False)
             else:
                 self.get_ctrlvars(timeout=1, warn=False)
@@ -677,9 +677,10 @@ class PV(object):
         return self._getarg('timestamp')
 
     @property
-    def seconds(self):
-        "integer seconds for timestamp of last pv action"
-        return self._getarg('seconds')
+    def posixseconds(self):
+        """integer seconds for timestamp of last pv action
+        using POSIX time convention"""
+        return self._getarg('posixseconds')
 
     @property
     def nanoseconds(self):

--- a/epics/pv.py
+++ b/epics/pv.py
@@ -89,7 +89,8 @@ class PV(object):
     _fmtarr = "<PV '%(pvname)s', count=%(count)i/%(nelm)i, type=%(typefull)s, access=%(access)s>"
     _fields = ('pvname',  'value',  'char_value',  'status',  'ftype',  'chid',
                'host', 'count', 'access', 'write_access', 'read_access',
-               'severity', 'timestamp', 'precision', 'units', 'enum_strs',
+               'severity', 'timestamp', 'seconds', 'nanoseconds',
+               'precision', 'units', 'enum_strs',
                'upper_disp_limit', 'lower_disp_limit', 'upper_alarm_limit',
                'lower_alarm_limit', 'lower_warning_limit',
                'upper_warning_limit', 'upper_ctrl_limit', 'lower_ctrl_limit')
@@ -442,6 +443,8 @@ class PV(object):
         self._args.update(kwd)
         self._args['value']  = value
         self._args['timestamp'] = kwd.get('timestamp', time.time())
+        self._args['seconds'] = kwd.get('seconds', 0)
+        self._args['nanoseconds'] = kwd.get('nanoseconds', 0)
         self._set_charval(self._args['value'], call_ca=False)
         if self.verbose:
             now = fmt_time(self._args['timestamp'])
@@ -548,6 +551,7 @@ class PV(object):
         for nam in ('char_value', 'count', 'nelm', 'type', 'units',
                     'precision', 'host', 'access',
                     'status', 'severity', 'timestamp',
+                    'seconds', 'nanoseconds',
                     'upper_ctrl_limit', 'lower_ctrl_limit',
                     'upper_disp_limit', 'lower_disp_limit',
                     'upper_alarm_limit', 'lower_alarm_limit',
@@ -587,7 +591,8 @@ class PV(object):
         if self._args['value'] is None:
             self.get()
         if self._args[arg] is None:
-            if arg in ('status', 'severity', 'timestamp'):
+            if arg in ('status', 'severity', 'timestamp',
+                       'seconds', 'nanoseconds'):
                 self.get_timevars(timeout=1, warn=False)
             else:
                 self.get_ctrlvars(timeout=1, warn=False)
@@ -670,6 +675,16 @@ class PV(object):
     def timestamp(self):
         "timestamp of last pv action"
         return self._getarg('timestamp')
+
+    @property
+    def seconds(self):
+        "integer seconds for timestamp of last pv action"
+        return self._getarg('seconds')
+
+    @property
+    def nanoseconds(self):
+        "integer nanoseconds for timestamp of last pv action"
+        return self._getarg('nanoseconds')
 
     @property
     def precision(self):


### PR DESCRIPTION
this addresses #70 and adds PV properties of `seconds` and `nanoseconds`, both of which are integers taken directly from the EPICS DBR timestamp.   The `nanosecond` property will give higher precision timing for PV events.