### PR TITLE
Fix puting single value to waveform of strings.

### DIFF
--- a/epics/ca.py
+++ b/epics/ca.py
@@ -1319,7 +1319,12 @@ def put(chid, value, wait=False, timeout=30, callback=None,
     if count > 1:
         # check that data for array PVS is a list, array, or string
         try:
-            count = min(len(value), count)
+            if ftype == dbr.STRING and is_string_or_bytes(value):
+                # len('abc') --> 3, however this is one element for dbr.STRING ftype
+                count = 1
+            else:
+                count = min(len(value), count)
+
             if count == 0:
                 count = nativecount
         except TypeError:
@@ -1333,9 +1338,9 @@ def put(chid, value, wait=False, timeout=30, callback=None,
     if is_string(value):
         value = ascii_string(value)
 
-    data  = (count*dbr.Map[ftype])()
+    data = (count*dbr.Map[ftype])()
     if ftype == dbr.STRING:
-        if count == 1:
+        if is_string_or_bytes(value):
             data[0].value = value
         else:
             for elem in range(min(count, len(value))):

--- a/epics/pv.py
+++ b/epics/pv.py
@@ -292,10 +292,10 @@ class PV(object):
             # respect count argument on subscription also for calls to get 
             if count is None and self._args['count']!=self._args['nelm']:
                 count = self._args['count']
-                
             ca_get = ca.get
             if ca.get_cache(self.pvname)['value'] is not None:
                 ca_get = ca.get_complete
+
             self._args['value'] = ca_get(self.chid, ftype=self.ftype,
                                          count=count, timeout=timeout,
                                          as_numpy=as_numpy)

--- a/epics/utils3.py
+++ b/epics/utils3.py
@@ -50,4 +50,4 @@ def is_string_or_bytes(s):
     return isinstance(s, str) or isinstance(s, bytes) 
 
 def ascii_string(s):
-    return bytes(s, EPICS_STR_ENCODING)
+    return bytes(str(s), EPICS_STR_ENCODING)

--- a/tests/ca_type_conversion.py
+++ b/tests/ca_type_conversion.py
@@ -15,6 +15,7 @@ pvlist = (
     pvnames.long_arr_pv,       
     pvnames.double_pv,
     pvnames.double_arr_pv,
+    pvnames.string_arr_pv,
     )
 
 

--- a/tests/pv_type_conversion.py
+++ b/tests/pv_type_conversion.py
@@ -20,6 +20,7 @@ pvlist = (
     pvnames.long_arr_pv,       
     pvnames.double_pv,
     pvnames.double_arr_pv,
+    pvnames.string_arr_pv,
     )
 
 def onConnect(pvname=None,  **kw):

--- a/tests/pv_unittest.py
+++ b/tests/pv_unittest.py
@@ -204,8 +204,9 @@ class PV_Tests(unittest.TestCase):
         with no_simulator_updates():
             pv = PV(pvnames.string_arr_pv)
             put_value = ['a', 2, 'b']
-            with self.assertRaises(TypeError):
-                pv.put(put_value, wait=True)
+            pv.put(put_value, wait=True)
+            get_value = pv.get(use_monitor=False)
+            numpy.testing.assert_array_equal(get_value, ['a', '2', 'b'])
 
     def test_put_string_waveform_empty_list(self):
         write('String Array: put empty list\n')

--- a/tests/pv_unittest.py
+++ b/tests/pv_unittest.py
@@ -83,15 +83,6 @@ class PV_Tests(unittest.TestCase):
             self.assertIsInstance(val[1], str)
             self.failUnless(len(val[1]) > 1)
 
-    def test_put_string_waveform(self):
-        write('String Array: \n')
-        with no_simulator_updates():
-            pv = PV(pvnames.string_arr_pv)
-            put_value = ['a', 'b', 'c']
-            pv.put(put_value)
-            get_value = pv.get(use_monitor=False, count=len(put_value))
-            numpy.testing.assert_array_equal(get_value, put_value)
-
     def test_putcomplete(self):
         write('Put with wait and put_complete (using real motor!) \n')
         vals = (1.35, 1.50, 1.44, 1.445, 1.45, 1.453, 1.446, 1.447, 1.450, 1.450, 1.490, 1.5, 1.500)
@@ -190,6 +181,49 @@ class PV_Tests(unittest.TestCase):
         self.failUnless(len(NEWVALS) > 3)
         mypv.clear_callbacks()
 
+    def test_put_string_waveform(self):
+        write('String Array: put\n')
+        with no_simulator_updates():
+            pv = PV(pvnames.string_arr_pv)
+            put_value = ['a', 'b', 'c']
+            pv.put(put_value, wait=True)
+            get_value = pv.get(use_monitor=False)
+            numpy.testing.assert_array_equal(get_value, put_value)
+
+    def test_put_string_waveform_single_element(self):
+        write('String Array: put single element\n')
+        with no_simulator_updates():
+            pv = PV(pvnames.string_arr_pv)
+            put_value = ['a']
+            pv.put(put_value, wait=True)
+            get_value = pv.get(use_monitor=False)
+            self.failUnless(put_value[0] == get_value)
+
+    def test_put_string_waveform_mixed_types(self):
+        write('String Array: put mixed types\n')
+        with no_simulator_updates():
+            pv = PV(pvnames.string_arr_pv)
+            put_value = ['a', 2, 'b']
+            with self.assertRaises(TypeError):
+                pv.put(put_value, wait=True)
+
+    def test_put_string_waveform_empty_list(self):
+        write('String Array: put empty list\n')
+        with no_simulator_updates():
+            pv = PV(pvnames.string_arr_pv)
+            put_value = []
+            pv.put(put_value, wait=True)
+            get_value = pv.get(use_monitor=False, as_numpy=False)
+            self.failUnless('' == ''.join(get_value))
+
+    def test_put_string_waveform_zero_length_strings(self):
+        write('String Array: put zero length strings\n')
+        with no_simulator_updates():
+            pv = PV(pvnames.string_arr_pv)
+            put_value = ['', '', '']
+            pv.put(put_value, wait=True)
+            get_value = pv.get(use_monitor=False)
+            numpy.testing.assert_array_equal(get_value, put_value)
 
     def test_subarrays(self):
         write("Subarray test:  dynamic length arrays\n")


### PR DESCRIPTION
Bug in ca.put() when working with waveforms of strings.

Old code is problematic since "cout" parameter is defined with "len(value)". In case of strings or bytes len() returns number of characters, but pypepics expects number of elements. When ftype == dbr.STRING, one string is one element, therefore count=1.

This results in following behaviour:
1) ca.put('abc')
- py2 .. instead of ['abc'], waveform will be ['a', 'b', 'c']
- py3 .. type error ... since value[i] is of type int if value is of type bytes

2) In second case when value is a list with a single element -->  ca.put(['abc'g), pyepics will try to handle it as a single value and will try to assign a list() to the object which expects strings(py2)/bytes(py3) ---> Type error.

This commit handles strings/bytes properly.