### PR TITLE
CI: tweak how docker is started

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_install:
   - docker pull ${DOCKERIMAGE}:${DOCKERTAG}
   - docker images
   - docker ps -a
-  - docker run -d -p $DOCKER0_IP:5064:5064/tcp -p $DOCKER0_IP:5065:5065/udp --name epics_iocs ${DOCKERIMAGE}:${DOCKERTAG}
+  - docker run -d -p $DOCKER0_IP:7000-8000:5064/tcp --name epics_iocs ${DOCKERIMAGE}:${DOCKERTAG}
   - docker ps -a
 
   # INSTALL CONDA

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ matrix:
     - python: 2.7
     - python: 3.4
     - python: 3.5
+    - python: 3.6
 
 before_install:
   - export DOCKER0_IP=$(/sbin/ifconfig docker0 |grep 'inet addr' | sed -e 's/.*addr:\([^ ]*\).*/\1/')


### PR DESCRIPTION
This will make it possible to start more than one docker instance
and have them live side-by-side.

This binds each servers 5064 tcp port to a random port in the range
7000-8000 which is sorted out by libca as part of the search process.

The udp multi-cast passes through on 5064 (as it did before).

We do not need to expose the heart-beat outside of the docker manager.