### PR TITLE
Iron python testing

### DIFF
--- a/epics/ca.py
+++ b/epics/ca.py
@@ -239,7 +239,11 @@ def initialize_libca():
 
     # save value offests used for unpacking
     # TIME and CTRL data as an array in dbr module
-    dbr.value_offset = (39*ctypes.c_short).in_dll(libca,'dbr_value_offset')
+
+    # in_dll is not available for arrays in IronPython, so use a reference to the first element
+    value_offset0 = ctypes.c_short.in_dll(libca,'dbr_value_offset')
+    dbr.value_offset = ctypes.cast(ctypes.addressof(value_offset0), (39*ctypes.c_short))
+
     initial_context = current_context()
     if AUTO_CLEANUP:
         atexit.register(finalize_libca)
@@ -855,7 +859,7 @@ def create_channel(pvname, connect=False, auto_cb=True, callback=None):
         chid = _cache[ctx][pvname]['chid']
     else:
         chid = dbr.chid_t()
-        ret = libca.ca_create_channel(pvn, conncb, 0, 0,
+        ret = libca.ca_create_channel(ctypes.c_char_p(pvn), conncb, 0, 0,
                                       ctypes.byref(chid))
         PySEVCHK('create_channel', ret)
         entry['chid'] = chid

--- a/epics/ca.py
+++ b/epics/ca.py
@@ -588,7 +588,7 @@ def _onGetEvent(args, **kws):
     if args.status != dbr.ECA_NORMAL:
         return
 
-    get_cache(name(args.chid))[args.usr] = memcopy(dbr.cast_args(args))
+    get_cache(name(args.chid))[args.usr.value] = (dbr.cast_args(args))
 
 
 ## put event handler:

--- a/epics/ca.py
+++ b/epics/ca.py
@@ -241,7 +241,7 @@ def initialize_libca():
     # TIME and CTRL data as an array in dbr module
 
     # in_dll is not available for arrays in IronPython, so use a reference to the first element
-    if dbr.isIronPython():
+    if dbr.IRON_PYTHON:
 	    value_offset0 = ctypes.c_short.in_dll(libca,'dbr_value_offset')
 	    dbr.value_offset = ctypes.cast(ctypes.addressof(value_offset0), (39*ctypes.c_short))
     else: 
@@ -591,7 +591,7 @@ def _onGetEvent(args, **kws):
     if args.status != dbr.ECA_NORMAL:
         return
 
-    if dbr.isIronPython():
+    if dbr.IRON_PYTHON:
         get_cache(name(args.chid))[args.usr.value] = (dbr.cast_args(args))
     else:
         get_cache(name(args.chid))[args.usr] = memcopy(dbr.cast_args(args))

--- a/epics/ca.py
+++ b/epics/ca.py
@@ -241,8 +241,11 @@ def initialize_libca():
     # TIME and CTRL data as an array in dbr module
 
     # in_dll is not available for arrays in IronPython, so use a reference to the first element
-    value_offset0 = ctypes.c_short.in_dll(libca,'dbr_value_offset')
-    dbr.value_offset = ctypes.cast(ctypes.addressof(value_offset0), (39*ctypes.c_short))
+    if dbr.IRONPY_WINDOWS:
+	    value_offset0 = ctypes.c_short.in_dll(libca,'dbr_value_offset')
+	    dbr.value_offset = ctypes.cast(ctypes.addressof(value_offset0), (39*ctypes.c_short))
+    else: 
+        dbr.value_offset = (39*ctypes.c_short).in_dll(libca,'dbr_value_offset')
 
     initial_context = current_context()
     if AUTO_CLEANUP:
@@ -588,7 +591,10 @@ def _onGetEvent(args, **kws):
     if args.status != dbr.ECA_NORMAL:
         return
 
-    get_cache(name(args.chid))[args.usr.value] = (dbr.cast_args(args))
+    if dbr.IRONPY_WINDOWS:
+        get_cache(name(args.chid))[args.usr.value] = (dbr.cast_args(args))
+    else:
+        get_cache(name(args.chid))[args.usr] = memcopy(dbr.cast_args(args))
 
 
 ## put event handler:

--- a/epics/ca.py
+++ b/epics/ca.py
@@ -241,7 +241,7 @@ def initialize_libca():
     # TIME and CTRL data as an array in dbr module
 
     # in_dll is not available for arrays in IronPython, so use a reference to the first element
-    if dbr.IRONPY_WINDOWS:
+    if dbr.isIronPython():
 	    value_offset0 = ctypes.c_short.in_dll(libca,'dbr_value_offset')
 	    dbr.value_offset = ctypes.cast(ctypes.addressof(value_offset0), (39*ctypes.c_short))
     else: 
@@ -591,7 +591,7 @@ def _onGetEvent(args, **kws):
     if args.status != dbr.ECA_NORMAL:
         return
 
-    if dbr.IRONPY_WINDOWS:
+    if dbr.isIronPython():
         get_cache(name(args.chid))[args.usr.value] = (dbr.cast_args(args))
     else:
         get_cache(name(args.chid))[args.usr] = memcopy(dbr.cast_args(args))

--- a/epics/dbr.py
+++ b/epics/dbr.py
@@ -24,7 +24,9 @@ except ImportError:
 PY64_WINDOWS =  (os.name == 'nt' and architecture()[0].startswith('64'))
 PY_MAJOR, PY_MINOR = sys.version_info[:2]
 
-IRONPY_WINDOWS = 'IronPython' in sys.version
+def isIronPython():
+    import platform
+    return platform.python_implementation() = 'IronPython'
 
 # EPICS Constants
 ECA_NORMAL = 1

--- a/epics/dbr.py
+++ b/epics/dbr.py
@@ -24,6 +24,8 @@ except ImportError:
 PY64_WINDOWS =  (os.name == 'nt' and architecture()[0].startswith('64'))
 PY_MAJOR, PY_MINOR = sys.version_info[:2]
 
+IRONPY_WINDOWS = 'IronPython' in sys.version
+
 # EPICS Constants
 ECA_NORMAL = 1
 ECA_TIMEOUT = 80

--- a/epics/dbr.py
+++ b/epics/dbr.py
@@ -26,7 +26,7 @@ PY_MAJOR, PY_MINOR = sys.version_info[:2]
 
 def isIronPython():
     import platform
-    return platform.python_implementation() = 'IronPython'
+    return platform.python_implementation() == 'IronPython'
 
 # EPICS Constants
 ECA_NORMAL = 1

--- a/epics/dbr.py
+++ b/epics/dbr.py
@@ -12,7 +12,7 @@ This is mostly copied from CA header files
 import ctypes
 import os
 import sys
-from platform import architecture
+import platform
 
 HAS_NUMPY = False
 try:
@@ -21,12 +21,9 @@ try:
 except ImportError:
     pass
 
-PY64_WINDOWS =  (os.name == 'nt' and architecture()[0].startswith('64'))
+PY64_WINDOWS =  (os.name == 'nt' and platform.architecture()[0].startswith('64'))
+IRON_PYTHON = platform.python_implementation() == 'IronPython'
 PY_MAJOR, PY_MINOR = sys.version_info[:2]
-
-def isIronPython():
-    import platform
-    return platform.python_implementation() == 'IronPython'
 
 # EPICS Constants
 ECA_NORMAL = 1


### PR DESCRIPTION
In follow up to http://www.aps.anl.gov/epics/tech-talk/2017/msg00797.php . . .

With this patch (based on work by @FreddieAkeroyd), pyepics is now working with IronPython (32-bit only). Tested on Windows 7 with IronPython 2.7.7 (2.7.7.0) on .NET 4.0.30319.42000 (32-bit)
using ca and Com dlls included with the pyepics distribution. 

Patched from tag 3.2.6. 