### PR TITLE
fix access rights structure for Py2 and Win64

### DIFF
--- a/epics/ca.py
+++ b/epics/ca.py
@@ -279,8 +279,9 @@ def initialize_libca():
 
     # in_dll is not available for arrays in IronPython, so use a reference to the first element
     if dbr.IRON_PYTHON:
-	    value_offset0 = ctypes.c_short.in_dll(libca,'dbr_value_offset')
-	    dbr.value_offset = ctypes.cast(ctypes.addressof(value_offset0), (39*ctypes.c_short))
+        value_offset0 = ctypes.c_short.in_dll(libca,'dbr_value_offset')
+        dbr.value_offset = ctypes.cast(ctypes.addressof(value_offset0),
+                                       (39*ctypes.c_short))
     else:
         dbr.value_offset = (39*ctypes.c_short).in_dll(libca,'dbr_value_offset')
 

--- a/epics/dbr.py
+++ b/epics/dbr.py
@@ -83,12 +83,12 @@ DBE_PROPERTY = 8
 
 chid_t   = ctypes.c_long
 
-# Note that Windows needs to be told that chid is 8 bytes for 64-bit, 
-# except that Python2 is very weird -- using a 4byte chid for 64-bit, 
-# but needing a 1 byte padding! 
+# Note that Windows needs to be told that chid is 8 bytes for 64-bit,
+# except that Python2 is very weird -- using a 4byte chid for 64-bit,
+# but needing a 1 byte padding!
 if PY64_WINDOWS and PY_MAJOR > 2:
     chid_t = ctypes.c_int64
-	
+
 short_t  = ctypes.c_short
 ushort_t = ctypes.c_ushort
 int_t    = ctypes.c_int
@@ -329,14 +329,14 @@ class event_handler_args(ctypes.Structure):
     "event handler arguments"
     _fields_ = [('usr',     ctypes.py_object),
                 ('chid',    chid_t),
-                ('type',    long_t), 
+                ('type',    long_t),
                 ('count',   long_t),
                 ('raw_dbr', void_p),
                 ('status',  int_t)]
 
 class connection_args(ctypes.Structure):
     "connection arguments"
-    _fields_ = [('chid', chid_t), 
+    _fields_ = [('chid', chid_t),
                 ('op', long_t)]
 
 class access_rights_handler_args(ctypes.Structure):
@@ -352,14 +352,21 @@ if PY64_WINDOWS and PY_MAJOR == 2:
         _fields_ = [('usr',     ctypes.py_object),
                     ('chid',    chid_t),
                     ('_pad_',   ctypes.c_int8),
-                    ('type',    ctypes.c_int32), 
+                    ('type',    ctypes.c_int32),
                     ('count',   ctypes.c_int32),
                     ('raw_dbr', void_p),
                     ('status',  ctypes.c_int32)]
 
     class connection_args(ctypes.Structure):
         "connection arguments"
-        _fields_ = [('chid', chid_t), 
+        _fields_ = [('chid', chid_t),
                     ('_pad_',ctypes.c_int8),
                     ('op',   long_t)]
 
+
+    class access_rights_handler_args(ctypes.Structure):
+        "access rights arguments"
+        _fields_ = [('chid', chid_t),
+                    ('_pad_',ctypes.c_int8),
+                    ('read_access', uint_t, 1),
+                    ('write_access', uint_t, 1)]


### PR DESCRIPTION
this is a small change for Python2 + Windows64 to add padding to the access_rights_handler structure.  It now works on Py2+Win64, and the change here should not affect any other platforms or parts of the code.