### PR TITLE
need to preload libCom on Windows

### DIFF
--- a/epics/ca.py
+++ b/epics/ca.py
@@ -119,8 +119,13 @@ def _find_lib(inp_lib_name):
     find location of ca dynamic library
     """
     # Test 1: if PYEPICS_LIBCA env var is set, use it.
-    dllpath = os.environ.get(
-        'PYEPICS_LIB{}'.format(inp_lib_name.upper()), None)
+    dllpath = os.environ.get('PYEPICS_LIBCA', None)
+
+    # find libCom.so *next to* libca.so if PYEPICS_LIBCA was set
+    if dllpath is not None and inp_lib_name != 'ca':
+        _parent, _name = os.path.split(dllpath)
+        dllpath = os.path.join(_parent, _name.replace('ca', inp_lib_name))
+    
     if (dllpath is not None and os.path.exists(dllpath) and
             os.path.isfile(dllpath)):
         return dllpath

--- a/epics/ca.py
+++ b/epics/ca.py
@@ -220,7 +220,8 @@ def initialize_libca():
         load_dll = ctypes.cdll.LoadLibrary
     try:
         # force loading the chosen version of libCom
-        load_dll(find_libCom())
+        if os.name == 'nt':
+            load_dll(find_libCom())
         libca = load_dll(find_libca())
     except Exception as exc:
         raise ChannelAccessException('loading Epics CA DLL failed: ' + str(exc))


### PR DESCRIPTION
This may resolve the Travis test failures with NOLIBCA. 

First,  pre-loading of libCom happens only on Windows, where it is necessary, but not on Linux, where it is not necessary, and where it was causing problems with the NOLIBCA option. 

Second, _find_lib() really looks at PYEPICS_LIBCA, but not for PYEPICS_LIBCOM even when looking for 'Com'.  If this envvar is set  but we're really looking for 'Com', it will look for libCom next to libca.

This does work for me on Windows 64bit.
