### PR TITLE
Improve batch-getting PVs.

### DIFF
--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -179,9 +179,9 @@ quite good.
 
 ..  function:: caget(pvname[, as_string=False[, count=None[, as_numpy=True[, timeout=None[, use_monitor=False]]]]])
 
-  retrieves and returns the value of the named PV.
+  retrieves and returns the value of the named PV(s).
 
-  :param pvname: name of Epics Process Variable
+  :param pvname: name of Epics Process Variable or list of names.
   :param as_string:  whether to return string representation of the PV value.
   :type as_string:  ``True``/``False``
   :param count:  number of elements to return for array data.
@@ -192,6 +192,9 @@ quite good.
   :type timeout:  float or ``None``
   :param use_monitor:  whether to rely on monitor callbacks or explicitly get value now.
   :type use_monitor: ``True``/``False``
+
+If *pvname* is a list of strings, :func:`caget_many` will be called
+instead with the same arguments.
 
 The *count* and *as_numpy* options apply only to array or waveform
 data. The default behavior is to return the full data array and convert to
@@ -271,6 +274,30 @@ desired::
 Of course,character waveforms are not always used for long strings,  but
 can also hold byte array data, such as comes from some detectors and
 devices.
+
+:func:`caget_many`
+~~~~~~~~~~~~~~~~~~
+
+..  function:: caget_many(pvlist[, as_string=False[, count=None[, as_numpy=True[, timeout=None]]]])
+
+  get a list of PVs as quickly as possible.  Returns a list of values for
+  each PV in the list.  Unlike :func:`caget`, this method does not use 
+  automatic monitoring (see :ref:`pv-automonitor-label`), even for large
+  waveform PVs.
+  
+  :param pvlist: A list of process variable names.
+  :type pvlist:  list of str
+  :param as_string:  whether to return string representation of the PV values.
+  :type as_string:  ``True``/``False``
+  :param count:  number of elements to return for array data.
+  :type count:  integer or ``None``
+  :param as_numpy:  whether to return the Numerical Python representation for array data.
+  :type as_numpy:  ``True``/``False``
+  :param timeout:  maximum time to wait (in seconds) for value before returning None.
+  :type timeout:  float or ``None``
+  
+For detailed information about the arguments, see the documentation for
+:func:`caget`.
 
 :func:`caput`
 ~~~~~~~~~~~~~~~~

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -418,8 +418,7 @@ and the log file is inspected::
 
   get a list of PVs as quickly as possible.  Returns a list of values for
   each PV in the list.  Unlike :func:`caget`, this method does not use 
-  automatic monitoring (see :ref:`pv-automonitor-label`), even for large
-  waveform PVs.
+  automatic monitoring (see :ref:`pv-automonitor-label`).
   
   :param pvlist: A list of process variable names.
   :type pvlist:  ``list`` or ``tuple`` of ``str``
@@ -443,7 +442,7 @@ For detailed information about the arguments, see the documentation for
   put values to a list of PVs as quickly as possible.  Returns a list of ints
   for each PV in the list: 1 if the put was successful, -1 if it timed out.
   Unlike :func:`caput`, this method does not use automatic monitoring (see
-  :ref:`pv-automonitor-label`), even for large waveform PVs.
+  :ref:`pv-automonitor-label`).
   
   :param pvlist: A list of process variable names.
   :type pvlist:  ``list`` or ``tuple`` of ``str``

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -449,11 +449,17 @@ For detailed information about the arguments, see the documentation for
   :type pvlist:  ``list`` or ``tuple`` of ``str``
   :param values: values to put to each PV.
   :type values: ``list`` or ``tuple``
-  :param wait:  whether or not to wait for processing to complete (or time-out) for each put before returning.
-  :type wait:  ``True``/``False``
-  :param connection_timeout:  maximum time to wait (in seconds) for a connection to be established to each PV.
+  :param wait:  if ``'each'``, :func:`caput_many` will wait for each 
+    PV to process before starting the next.  If ``'all'``,
+    :func:`caput_many` will issue puts for all PVs immediately, then
+    wait for all of them to complete.  If any other value,
+    :func:`caput_many` will not wait for put processing to complete.
+  :param connection_timeout:  maximum time to wait (in seconds) for 
+    a connection to be established to each PV.
   :type connection_timeout:  float or ``None``
-  :param put_timeout: maximum time to wait (in seconds) for processing to complete for each PV.
+  :param put_timeout: maximum time to wait (in seconds) for processing
+   to complete for each PV (if ``wait`` is ``'each'``), or for processing
+   to complete for all PVs (if ``wait`` is ``'all'``).
   :type put_timeout: float or ``None``
   
 Because connections to channels normally connect very quickly (less than a

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -286,7 +286,7 @@ devices.
   waveform PVs.
   
   :param pvlist: A list of process variable names.
-  :type pvlist:  list of str
+  :type pvlist:  ``list`` of ``str``
   :param as_string:  whether to return string representation of the PV values.
   :type as_string:  ``True``/``False``
   :param count:  number of elements to return for array data.

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -422,7 +422,7 @@ and the log file is inspected::
   waveform PVs.
   
   :param pvlist: A list of process variable names.
-  :type pvlist:  ``list`` of ``str``
+  :type pvlist:  ``list`` or ``tuple`` of ``str``
   :param as_string:  whether to return string representation of the PV values.
   :type as_string:  ``True``/``False``
   :param count:  number of elements to return for array data.

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -275,30 +275,6 @@ Of course,character waveforms are not always used for long strings,  but
 can also hold byte array data, such as comes from some detectors and
 devices.
 
-:func:`caget_many`
-~~~~~~~~~~~~~~~~~~
-
-..  function:: caget_many(pvlist[, as_string=False[, count=None[, as_numpy=True[, timeout=None]]]])
-
-  get a list of PVs as quickly as possible.  Returns a list of values for
-  each PV in the list.  Unlike :func:`caget`, this method does not use 
-  automatic monitoring (see :ref:`pv-automonitor-label`), even for large
-  waveform PVs.
-  
-  :param pvlist: A list of process variable names.
-  :type pvlist:  ``list`` of ``str``
-  :param as_string:  whether to return string representation of the PV values.
-  :type as_string:  ``True``/``False``
-  :param count:  number of elements to return for array data.
-  :type count:  integer or ``None``
-  :param as_numpy:  whether to return the Numerical Python representation for array data.
-  :type as_numpy:  ``True``/``False``
-  :param timeout:  maximum time to wait (in seconds) for value before returning None.
-  :type timeout:  float or ``None``
-  
-For detailed information about the arguments, see the documentation for
-:func:`caget`.
-
 :func:`caput`
 ~~~~~~~~~~~~~~~~
 
@@ -435,6 +411,29 @@ and the log file is inspected::
     XXX:DMM1Ch2_calc.VAL 2010-03-24 11:56:47.536623 -183.5223
     XXX:DMM1Ch2_calc.VAL 2010-03-24 11:56:48.536434 -183.6832
 
+:func:`caget_many`
+~~~~~~~~~~~~~~~~~~
+
+..  function:: caget_many(pvlist[, as_string=False[, count=None[, as_numpy=True[, timeout=None]]]])
+
+  get a list of PVs as quickly as possible.  Returns a list of values for
+  each PV in the list.  Unlike :func:`caget`, this method does not use 
+  automatic monitoring (see :ref:`pv-automonitor-label`), even for large
+  waveform PVs.
+  
+  :param pvlist: A list of process variable names.
+  :type pvlist:  ``list`` of ``str``
+  :param as_string:  whether to return string representation of the PV values.
+  :type as_string:  ``True``/``False``
+  :param count:  number of elements to return for array data.
+  :type count:  integer or ``None``
+  :param as_numpy:  whether to return the Numerical Python representation for array data.
+  :type as_numpy:  ``True``/``False``
+  :param timeout:  maximum time to wait (in seconds) for value before returning None.
+  :type timeout:  float or ``None``
+  
+For detailed information about the arguments, see the documentation for
+:func:`caget`.
 
 Motivation: Why another Python-Epics Interface?
 ================================================

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -435,6 +435,33 @@ and the log file is inspected::
 For detailed information about the arguments, see the documentation for
 :func:`caget`.
 
+:func:`caput_many`
+~~~~~~~~~~~~~~~~~~
+
+..  function:: caput_many(pvlist, values[, wait=False[, connection_timeout=None[, put_timeout=60]]])
+
+  put values to a list of PVs as quickly as possible.  Returns a list of ints
+  for each PV in the list: 1 if the put was successful, -1 if it timed out.
+  Unlike :func:`caput`, this method does not use automatic monitoring (see
+  :ref:`pv-automonitor-label`), even for large waveform PVs.
+  
+  :param pvlist: A list of process variable names.
+  :type pvlist:  ``list`` or ``tuple`` of ``str``
+  :param values: values to put to each PV.
+  :type values: ``list`` or ``tuple``
+  :param wait:  whether or not to wait for processing to complete (or time-out) for each put before returning.
+  :type wait:  ``True``/``False``
+  :param connection_timeout:  maximum time to wait (in seconds) for a connection to be established to each PV.
+  :type connection_timeout:  float or ``None``
+  :param put_timeout: maximum time to wait (in seconds) for processing to complete for each PV.
+  :type put_timeout: float or ``None``
+  
+Because connections to channels normally connect very quickly (less than a
+second), but processing a put may take a significant amount of time (due to 
+a physical device moving, or due to complex calculations or data processing
+sequences), a separate timeout duration can be specified for connections and
+processing puts.
+
 Motivation: Why another Python-Epics Interface?
 ================================================
 

--- a/epics/__init__.py
+++ b/epics/__init__.py
@@ -80,7 +80,7 @@ def caget(pvname, as_string=False, count=None, as_numpy=True,
     
     if pvname is a list of strings, caget_many is called instead.
     """
-    if isinstance(pvname, list):
+    if isinstance(pvname, (list, tuple)):
         return caget_many(pvname,
                           as_string=as_string,
                           count=count,

--- a/epics/__init__.py
+++ b/epics/__init__.py
@@ -177,5 +177,23 @@ def caget_many(pvlist, as_string=False, count=None, as_numpy=True, timeout=5.0):
                                                   timeout=timeout))
     return out
 
-
+def caput_many(pvlist, values, wait=False, connection_timeout=None, put_timeout=60):
+    """put values to a list of PVs
+    This does not maintain PV objects.  If wait is true,
+    *each* put operation will block until it is complete.
+    Returns a list of integers for each PV, 1 if the put
+    was successful, or a negative number if the timeout
+    was exceeded.
+    """
+    chids, out, conns = [], [], []
+    for name in pvlist: chids.append(ca.create_channel(name,
+                                                       auto_cb=False,
+                                                       connect=False))
+    for chid in chids: conns.append(ca.connect_channel(chid, timeout=connection_timeout))
+    for (i, chid) in enumerate(chids):
+        if conns[i]:
+            out.append(ca.put(chid, values[i], wait=wait, timeout=put_timeout))
+        else:
+            out.append(-1)
+    return out
 

--- a/epics/__init__.py
+++ b/epics/__init__.py
@@ -84,7 +84,7 @@ def caget(pvname, as_string=False, count=None, as_numpy=True,
         return caget_many(pvname,
                           as_string=as_string,
                           count=count,
-                          as_numpy=as_numpy
+                          as_numpy=as_numpy,
                           timeout=timeout)
     start_time = time.time()
     thispv = get_pv(pvname, timeout=timeout, connect=True)

--- a/epics/__init__.py
+++ b/epics/__init__.py
@@ -78,15 +78,7 @@ def caget(pvname, as_string=False, count=None, as_numpy=True,
     to get a truncated amount of data from an array, you can specify
     the count with
        >>> x = caget('MyArray.VAL', count=1000)
-    
-    if pvname is a list of strings, caget_many is called instead.
     """
-    if isinstance(pvname, (list, tuple)):
-        return caget_many(pvname,
-                          as_string=as_string,
-                          count=count,
-                          as_numpy=as_numpy,
-                          timeout=timeout)
     start_time = time.time()
     thispv = get_pv(pvname, timeout=timeout, connect=True)
     if thispv.connected:

--- a/epics/__init__.py
+++ b/epics/__init__.py
@@ -77,7 +77,15 @@ def caget(pvname, as_string=False, count=None, as_numpy=True,
     to get a truncated amount of data from an array, you can specify
     the count with
        >>> x = caget('MyArray.VAL', count=1000)
+    
+    if pvname is a list of strings, caget_many is called instead.
     """
+    if isinstance(pvname, list):
+        return caget_many(pvname,
+                          as_string=as_string,
+                          count=count,
+                          as_numpy=as_numpy
+                          timeout=timeout)
     start_time = time.time()
     thispv = get_pv(pvname, timeout=timeout, connect=True)
     if thispv.connected:
@@ -151,7 +159,7 @@ def camonitor(pvname, writer=None, callback=None):
         thispv.add_callback(callback, index=-999, with_ctrlvars=True)
         _PVmonitors_[pvname] = thispv
 
-def caget_many(pvlist):
+def caget_many(pvlist, as_string=False, count=None, as_numpy=True, timeout=5.0):
     """get values for a list of PVs
     This does not maintain PV objects, and works as fast
     as possible to fetch many values.
@@ -161,8 +169,12 @@ def caget_many(pvlist):
                                                        auto_cb=False,
                                                        connect=False))
     for chid in chids: ca.connect_channel(chid)
-    for chid in chids: ca.get(chid, wait=False)
-    for chid in chids: out.append(ca.get_complete(chid))
+    for chid in chids: ca.get(chid, count=count, as_string=as_string, as_numpy=as_numpy, wait=False)
+    for chid in chids: out.append(ca.get_complete(chid, 
+                                                  count=count, 
+                                                  as_string=as_string, 
+                                                  as_numpy=as_numpy, 
+                                                  timeout=timeout))
     return out
 
 

--- a/epics/ca.py
+++ b/epics/ca.py
@@ -1352,7 +1352,7 @@ def put(chid, value, wait=False, timeout=30, callback=None,
         before returning.
     timeout : float
         maximum time to wait for processing to complete before returning anyway.
-    callback : ``None`` of callable
+    callback : ``None`` or callable
         user-supplied function to run when processing has completed.
     callback_data :  object
         extra data to pass on to a user-supplied callback function.

--- a/tests/pv_unittest.py
+++ b/tests/pv_unittest.py
@@ -7,7 +7,7 @@ import time
 import unittest
 import numpy
 from contextlib import contextmanager
-from epics import PV, caput, caget, caget_many, ca
+from epics import PV, caput, caget, caget_many, caput_many, ca
 
 import pvnames
 
@@ -64,13 +64,23 @@ class PV_Tests(unittest.TestCase):
         self.assertEqual(sval, 'ao')
 
     def test_caget_many(self):
-        write('Simple Test of caget_multi() function\n')
+        write('Simple Test of caget_many() function\n')
         pvs = [pvnames.double_pv, pvnames.enum_pv, pvnames.str_pv]
         vals = caget_many(pvs)
         self.assertEqual(len(vals), len(pvs))
         self.assertIsInstance(vals[0], float)
         self.assertIsInstance(vals[1], int)
         self.assertIsInstance(vals[2], str)
+
+    def test_caput_many(self):
+        write('Simple Test of caput_many() function\n')
+        pvs = [pvnames.double_pv, pvnames.enum_pv, 'ceci nest pas une PV']
+        vals = [0.5, 0, 23]
+        success = caput_many(pvs, vals, connection_timeout=0.5)
+        self.assertEqual(len(success), len(pvs))
+        self.assertEqual(success[0], 1)
+        self.assertEqual(success[1], 1)
+        self.failUnless(success[2] < 0)
 
     def test_get1(self):
         write('Simple Test: test value and char_value on an integer\n')

--- a/tests/pv_unittest.py
+++ b/tests/pv_unittest.py
@@ -72,12 +72,40 @@ class PV_Tests(unittest.TestCase):
         self.assertIsInstance(vals[1], int)
         self.assertIsInstance(vals[2], str)
 
-    def test_caput_many(self):
-        write('Simple Test of caput_many() function\n')
+    def test_caput_many_wait_all(self):
+        write('Test of caput_many() function, waiting for all.\n')
         pvs = [pvnames.double_pv, pvnames.enum_pv, 'ceci nest pas une PV']
+        #pvs = ["MTEST:Val1", "MTEST:Val2", "MTEST:SlowVal"]
         vals = [0.5, 0, 23]
-        success = caput_many(pvs, vals, connection_timeout=0.5)
+        t0 = time.time()
+        success = caput_many(pvs, vals, wait='all', connection_timeout=0.5, put_timeout=5.0)
+        t1 = time.time()
         self.assertEqual(len(success), len(pvs))
+        self.assertEqual(success[0], 1)
+        self.assertEqual(success[1], 1)
+        self.failUnless(success[2] < 0)
+        
+    
+    def test_caput_many_wait_each(self):
+        write('Simple Test of caput_many() function, waiting for each.\n')
+        pvs = [pvnames.double_pv, pvnames.enum_pv, 'ceci nest pas une PV']
+        #pvs = ["MTEST:Val1", "MTEST:Val2", "MTEST:SlowVal"]
+        vals = [0.5, 0, 23]
+        success = caput_many(pvs, vals, wait='each', connection_timeout=0.5, put_timeout=1.0)
+        self.assertEqual(len(success), len(pvs))
+        self.assertEqual(success[0], 1)
+        self.assertEqual(success[1], 1)
+        self.failUnless(success[2] < 0)
+
+    def test_caput_many_no_wait(self):
+        write('Simple Test of caput_many() function, without waiting.\n')
+        pvs = [pvnames.double_pv, pvnames.enum_pv, 'ceci nest pas une PV']
+        #pvs = ["MTEST:Val1", "MTEST:Val2", "MTEST:SlowVal"]
+        vals = [0.5, 0, 23]
+        success = caput_many(pvs, vals, wait=None, connection_timeout=0.5)
+        self.assertEqual(len(success), len(pvs))
+        #If you don't wait, ca.put returns 1 as long as the PV connects
+        #and the put request is valid.
         self.assertEqual(success[0], 1)
         self.assertEqual(success[1], 1)
         self.failUnless(success[2] < 0)

--- a/tests/pv_unittest.py
+++ b/tests/pv_unittest.py
@@ -7,7 +7,7 @@ import time
 import unittest
 import numpy
 from contextlib import contextmanager
-from epics import PV, caput, caget, ca
+from epics import PV, caput, caget, caget_many, ca
 
 import pvnames
 
@@ -62,6 +62,15 @@ class PV_Tests(unittest.TestCase):
             self.assertIsNot(val, None)
         sval = caget(pvnames.str_pv)
         self.assertEqual(sval, 'ao')
+
+    def test_caget_many(self):
+        write('Simple Test of caget_multi() function\n')
+        pvs = [pvnames.double_pv, pvnames.enum_pv, pvnames.str_pv]
+        vals = caget_many(pvs)
+        self.assertEqual(len(vals), len(pvs))
+        self.assertIsInstance(vals[0], float)
+        self.assertIsInstance(vals[1], int)
+        self.assertIsInstance(vals[2], str)
 
     def test_get1(self):
         write('Simple Test: test value and char_value on an integer\n')


### PR DESCRIPTION
This PR improves the epics.caget_many method to accept the same arguments as epics.caget, adds documentation for epics.caget_many, and adds a feature to epics.caget where if you pass it a list or tuple of PV names, it will call epics.caget_many.

A (very basic) unit test for epics.caget_many has been added as well.