### PR TITLE
Nopoll on ca create conncb

### DIFF
--- a/epics/ca.py
+++ b/epics/ca.py
@@ -125,7 +125,7 @@ def _find_lib(inp_lib_name):
     if dllpath is not None and inp_lib_name != 'ca':
         _parent, _name = os.path.split(dllpath)
         dllpath = os.path.join(_parent, _name.replace('ca', inp_lib_name))
-    
+
     if (dllpath is not None and os.path.exists(dllpath) and
             os.path.isfile(dllpath)):
         return dllpath
@@ -890,7 +890,6 @@ def create_channel(pvname, connect=False, auto_cb=True, callback=None):
               not callback in entry['callbacks']):
             entry['callbacks'].append(callback)
             callback(chid=entry['chid'], pvname=pvname, conn=entry['conn'])
-
     conncb = 0
     if auto_cb:
         conncb = _CB_CONNECT
@@ -903,16 +902,12 @@ def create_channel(pvname, connect=False, auto_cb=True, callback=None):
                                       ctypes.byref(chid))
         PySEVCHK('create_channel', ret)
         entry['chid'] = chid
-
     chid_key = chid
     if isinstance(chid_key, dbr.chid_t):
         chid_key = chid.value
     _namecache[chid_key] = BYTES2STR(pvn)
-    # print("CREATE Channel ", pvn, chid)
     if connect:
         connect_channel(chid)
-    if conncb != 0:
-        poll()
     return chid
 
 @withCHID

--- a/tests/pv_unittest.py
+++ b/tests/pv_unittest.py
@@ -32,10 +32,11 @@ def onChanges(pvname=None, value=None, **kws):
 def no_simulator_updates():
     '''Context manager which pauses and resumes simulator PV updating'''
     try:
-        caput(pvnames.pause_pv, 1)
+        caput(pvnames.pause_pv, 1, wait=True)
+        time.sleep(0.05)
         yield
     finally:
-        caput(pvnames.pause_pv, 0)
+        caput(pvnames.pause_pv, 0, wait=True)
 
 
 class PV_Tests(unittest.TestCase):


### PR DESCRIPTION
This PR changes `ca.create_channel` to remove the `poll()` if a connection callback is defined (as is usual).  On Windows64, this call was definitely slow -- taking ~15 ms -- which is not seen on Linux or OSX. 

I'm not sure why that poll is necessary.  That is, it still doesn't ensure that the connection callback has been run before `create_channel` returns.  

FWIW, there is also a change to add more things to the initial list of motor attributes, which is how I started looking into this problem in the first place.   

Travis seems to say this is passing, which is pleasantly surprising -- I half expected a failure when testing connection callbacks.

I'm not sure this needs to be merged immediately.  But, any objections or concerns?

