### PR TITLE
add posixseconds/nanoseconds to output of get_timevars()

### DIFF
--- a/epics/ca.py
+++ b/epics/ca.py
@@ -1550,6 +1550,8 @@ def get_timevars(chid, timeout=5.0, warn=True):
             out[attr] = getattr(tmpv, attr)
     if hasattr(tmpv, 'stamp'):
         out['timestamp'] = dbr.make_unixtime(tmpv.stamp)
+        out['posixseconds'] = tmpv.stamp.secs + dbr.EPICS2UNIX_EPOCH
+        out['nanoseconds'] = tmpv.stamp.nsec
 
     ncache['time_value'] = None
     return out


### PR DESCRIPTION
this addresses #117, adding `posixseconds` and `nanoseconds` elements to the dict returned by `ca.get_timevars()`.  