### PR TITLE
Add another method to find shared libraries using 'ld'

### DIFF
--- a/epics/ca.py
+++ b/epics/ca.py
@@ -212,9 +212,10 @@ def _find_lib(inp_lib_name):
         return dllpath
 
     # If we still didn't find it (which is likely in Python<3.6), use a method back-ported from Python 3.6.
-    dllpath = _findLib_ld(inp_lib_name)
-    if dllpath is not None:
-        return dllpath
+    if os.name == 'posix':
+        dllpath = _findLib_ld(inp_lib_name)
+        if dllpath is not None:
+            return dllpath
 
     raise ChannelAccessException('cannot find Epics CA DLL')
 


### PR DESCRIPTION
This is my attempt at fixing #116 by using the linker to find shared libraries.  This is pretty much back-porting something that ctypes.find_library() does starting in Python 3.6.

To test it:
1. Clear 'PYEPICS_LIBCA' environment variable
2. Remove the bundled libraries in epics/clibs/
3. Ensure libca and libCom are in LD_LIBRARY_PATH (or DYLD_LIBRARY_PATH on Darwin)
4. Run epics.ca.initialize_libca() and see if it finds the library in your LD_LIBRARY_PATH.