### PR TITLE
ENH: on PV.get(), update all CTRL/STS/TIME metadata

### DIFF
--- a/doc/ca.rst
+++ b/doc/ca.rst
@@ -276,9 +276,13 @@ keyword arguments can be used to specify such options.
    function.
 
 
+.. autofunction:: get_with_metadata(chid, ftype=None, count=None, as_string=False, as_numpy=True, wait=True, timeout=None)
+
 .. autofunction:: get_complete(chid, ftype=None, count=None, as_string=False, as_numpy=True, timeout=None)
 
    See :ref:`advanced-get-timeouts-label` for further discussion.
+
+.. autofunction:: get_complete_with_metadata(chid, ftype=None, count=None, as_string=False, as_numpy=True, timeout=None)
 
 .. autofunction::  put(chid, value, wait=False, timeout=30, callback=None, callback_data=None)
 

--- a/epics/ca.py
+++ b/epics/ca.py
@@ -1659,17 +1659,15 @@ def get_timevars(chid, timeout=5.0, warn=True):
                 warnings.warn(msg % (name(chid), timeout))
             return {}
 
-    tmpv = ncache['time_value'][0]
-    for attr in ('status', 'severity'):
-        if hasattr(tmpv, attr):
-            out[attr] = getattr(tmpv, attr)
-    if hasattr(tmpv, 'stamp'):
-        out['timestamp'] = dbr.make_unixtime(tmpv.stamp)
-        out['posixseconds'] = tmpv.stamp.secs + dbr.EPICS2UNIX_EPOCH
-        out['nanoseconds'] = tmpv.stamp.nsec
+    try:
+        extended_data = ncache['time_value'][0]
+    except TypeError:
+        return {}
 
+    out = _unpack_metadata(ftype=ftype, dbr_value=extended_data)
     ncache['time_value'] = None
     return out
+
 
 def get_timestamp(chid):
     """return the timestamp of a Channel -- the time of last update."""

--- a/epics/pv.py
+++ b/epics/pv.py
@@ -365,11 +365,16 @@ class PV(object):
             else:
                 self.get_ctrlvars()
 
+        try:
+            cached_length = len(self._args['value'])
+        except TypeError:
+            cached_length = 1
+
         if ((not use_monitor) or
                 (not self.auto_monitor) or
                 (ftype != self.ftype) or
                 (self._args['value'] is None) or
-                (count is not None and count > len(self._args['value']))):
+                (count is not None and count > cached_length)):
 
             # respect count argument on subscription also for calls to get
             if count is None and self._args['count']!=self._args['nelm']:

--- a/epics/pv.py
+++ b/epics/pv.py
@@ -384,12 +384,18 @@ class PV(object):
             if md is None:
                 # Get failed. Indicate with a `None` as the return value
                 return
-            else:
-                val = md['value']
-                # Update value and all included metadata. Depending on the PV
-                # form, this could include timestamp, alarm information,
-                # ctrlvars, and so on.
-                self._args.update(**md)
+
+            # Update value and all included metadata. Depending on the PV
+            # form, this could include timestamp, alarm information,
+            # ctrlvars, and so on.
+            self._args.update(**md)
+
+            if with_ctrlvars and form != 'ctrl':
+                # If the user requested ctrlvars and they were not included in
+                # the request, return all metadata.
+                md = self._args.copy()
+
+            val = md['value']
         else:
             md = self._args.copy()
             val = self._args['value']

--- a/epics/pv.py
+++ b/epics/pv.py
@@ -437,7 +437,7 @@ class PV(object):
 
         # Update based on the requested type:
         md['value'] = val
-        return val
+        return md
 
     def put(self, value, wait=False, timeout=30.0,
             use_complete=False, callback=None, callback_data=None):

--- a/epics/pv.py
+++ b/epics/pv.py
@@ -9,12 +9,16 @@
 import time
 import ctypes
 import copy
-import types
 from math import log10
 
 from . import ca
 from . import dbr
 from .utils import is_string
+
+try:
+    from types import SimpleNamespace as Namespace
+except ImportError:
+    from argparse import Namespace
 
 _PVcache_ = {}
 
@@ -448,7 +452,7 @@ class PV(object):
             md['value'] = val
 
         if as_namespace:
-            return types.SimpleNamespace(**md)
+            return Namespace(**md)
         return md
 
     def put(self, value, wait=False, timeout=30.0,

--- a/tests/pv_unittest.py
+++ b/tests/pv_unittest.py
@@ -139,6 +139,11 @@ class PV_Tests(unittest.TestCase):
             assert 'timestamp' in md
             assert 'lower_ctrl_limit' in md
 
+            # Get a namespace
+            ns = pv.get_with_metadata(use_monitor=True, as_namespace=True)
+            assert hasattr(ns, 'timestamp')
+            assert hasattr(ns, 'lower_ctrl_limit')
+
     def test_get_string_waveform(self):
         write('String Array: \n')
         with no_simulator_updates():

--- a/tests/pv_unittest.py
+++ b/tests/pv_unittest.py
@@ -85,8 +85,8 @@ class PV_Tests(unittest.TestCase):
         self.assertEqual(success[0], 1)
         self.assertEqual(success[1], 1)
         self.failUnless(success[2] < 0)
-        
-    
+
+
     def test_caput_many_wait_each(self):
         write('Simple Test of caput_many() function, waiting for each.\n')
         pvs = [pvnames.double_pv, pvnames.enum_pv, 'ceci nest pas une PV']
@@ -119,6 +119,25 @@ class PV_Tests(unittest.TestCase):
             cval = pv.get(as_string=True)
 
             self.failUnless(int(cval)== val)
+
+    def test_get_with_metadata(self):
+        with no_simulator_updates():
+            pv = PV(pvnames.int_pv, form='native')
+
+            # Request time type
+            md = pv.get_with_metadata(use_monitor=False, form='time')
+            assert 'timestamp' in md
+            assert 'lower_ctrl_limit' not in md
+
+            # Request control type
+            md = pv.get_with_metadata(use_monitor=False, form='ctrl')
+            assert 'lower_ctrl_limit' in md
+            assert 'timestamp' not in md
+
+            # Use monitor: all metadata should come through
+            md = pv.get_with_metadata(use_monitor=True)
+            assert 'timestamp' in md
+            assert 'lower_ctrl_limit' in md
 
     def test_get_string_waveform(self):
         write('String Array: \n')

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -1,7 +1,9 @@
 from __future__ import print_function
+import sys
 from contextlib import contextmanager
 import epics
 import multiprocessing as mp
+import pytest
 
 import pvnames
 PVS = [pvnames.double_pv, pvnames.double_pv2]
@@ -14,6 +16,9 @@ def pool_ctx():
     pool.close()
     pool.join()
 
+
+@pytest.mark.skipif(sys.version_info >= (3, 0),
+                    reason='CAPool not functioning in Python 3')
 def test_caget():
     with pool_ctx() as pool:
         print('Using caget() in subprocess pools:')
@@ -28,6 +33,8 @@ def _manager_test_fcn(pv_dict, pv):
     pv_dict[pv] = epics.caget(pv)
 
 
+@pytest.mark.skipif(sys.version_info >= (3, 0),
+                    reason='CAPool not functioning in Python 3')
 def test_manager():
     '''
     Fill up a shared dictionary using a manager


### PR DESCRIPTION
Goal
----
* Update `epics.PV` metadata when `PV.get()` is called. 
* Allow access to metadata and value from a specific get request through `PV.get_with_metadata()`, where a kwarg can indicate a request for different DBR types: `ctrl`, `time`, or `None` (default to PV.form)

API additions were needed to make this possible, but it should all be backward-compatible. The original `epics.ca.get` and `epics.ca.get_complete` just now call the 'metadata-rich' versions `epics.ca.get_with_metadata` and `epics.ca.get_complete_with_metadata`.

Metadata update example
-------------
If `pv.form` is set to 'time', then timestamp, status, severity will all be updated before returning. This means that `pv.timestamp` now accurately reflects the timestamp just received from the get request.

Similarly, if `pv.form` is 'ctrl', then all control metadata should be updated on each `.get()` call. 

`PV.get_with_metadata` example
----------
```python
In [1]: import epics

In [2]: mtr1 = epics.PV('sim:mtr1', form='native')

In [3]: mtr1.get_with_metadata(form='ctrl')
Out[3]:
{'upper_disp_limit': 100.0,
 'lower_disp_limit': -100.0,
 'upper_alarm_limit': 0.0,
 'upper_warning_limit': 0.0,
 'lower_warning_limit': 0.0,
 'lower_alarm_limit': 0.0,
 'upper_ctrl_limit': 100.0,
 'lower_ctrl_limit': -100.0,
 'precision': 3,
 'units': 'deg',
 'status': 0,
 'severity': 0,
 'value': 0.0}

In [4]: mtr1.get_with_metadata(form='time')
Out[4]:
{'status': 0,
 'severity': 0,
 'timestamp': 1543429156.811018,
 'posixseconds': 1543429156.0,
 'nanoseconds': 811018603,
 'value': 0.0}

In [5]: mtr1.get_with_metadata(form='time', as_string=True)
Out[5]:
{'status': 0,
 'severity': 0,
 'timestamp': 1543429156.811018,
 'posixseconds': 1543429156.0,
 'nanoseconds': 811018603,
 'value': '0'}
```

Improves
----------
* The case where `auto_monitor=False` - which requires separate calls to `get_timevars` or `get_ctrlvars` to update metadata
* `pv.get(with_ctrlvars=True)` when `pv.form='ctrl'` does not make 2 get requests
* Less code-duplication in `epics.ca`, moves all the metadata unpacking to one function (`epics.ca._unpack_metadata`)