### PR TITLE
allow get to return  (as documented) for unconnected Channels

### DIFF
--- a/epics/ca.py
+++ b/epics/ca.py
@@ -1179,7 +1179,7 @@ def _unpack_metadata(ftype, dbr_value):
     return md
 
 
-@withConnectedCHID
+@withCHID
 def get_with_metadata(chid, ftype=None, count=None, wait=True, timeout=None,
                       as_string=False, as_numpy=True):
     """Return the current value along with metadata for a Channel
@@ -1251,7 +1251,7 @@ def get_with_metadata(chid, ftype=None, count=None, wait=True, timeout=None,
                                           as_numpy=as_numpy)
 
 
-@withConnectedCHID
+@withCHID
 def get(chid, ftype=None, count=None, wait=True, timeout=None,
         as_string=False, as_numpy=True):
     """return the current value for a Channel.
@@ -1320,7 +1320,7 @@ def get(chid, ftype=None, count=None, wait=True, timeout=None,
             else None)
 
 
-@withConnectedCHID
+@withCHID
 def get_complete_with_metadata(chid, ftype=None, count=None, timeout=None,
                                as_string=False, as_numpy=True):
     """Returns the current value and associated metadata for a Channel
@@ -1399,7 +1399,7 @@ def get_complete_with_metadata(chid, ftype=None, count=None, timeout=None,
     return metadata
 
 
-@withConnectedCHID
+@withCHID
 def get_complete(chid, ftype=None, count=None, timeout=None, as_string=False,
                  as_numpy=True):
     """returns the current value for a Channel, completing an

--- a/tests/Setup/simulator.py
+++ b/tests/Setup/simulator.py
@@ -86,7 +86,7 @@ def initialize_data():
 
     pause_pv.put(0)
     str_waves[0].put([" String %i" % (i+1) for i in range(128)])
-    print 'Data initialized'
+    print( 'Data initialized')
 
 text = '''line 1
 this is line 2
@@ -115,7 +115,7 @@ while True:
     time.sleep(SLEEP_TIME)
 
     count = count + 1
-    if count  == 3: print 'running'
+    if count  == 3: print( 'running')
     if count > 99999999: count = 1
 
     t0 = time.time()

--- a/tests/ca_unittest.py
+++ b/tests/ca_unittest.py
@@ -63,7 +63,8 @@ class CA_BasicTests(unittest.TestCase):
     def testA_GetNonExistentPV(self):
         write('Simple Test: get on a non-existent PV')
         chid = ca.create_channel('Definitely-Not-A-Real-PV')
-        self.assertRaises(ca.ChannelAccessException, ca.get, chid)
+        val = ca.get(chid)
+        self.assertEqual(val, None)
 
     def testA_CreateChid_CheckTypeCount(self):
         write('Simple Test: create chid, check count, type, host, and access')


### PR DESCRIPTION
This allows `ca.get()` and related `ca.get***` to run with an unconnected channel ID and return `None` for an unconnected channel,  and not simply raise an exception in the decorator.  

This should address #141 