### PR TITLE
REF/FIX: cache race conditions, put_complete, and more...

### DIFF
--- a/epics/ca.py
+++ b/epics/ca.py
@@ -411,24 +411,6 @@ def get_cache(pvname):
     return _cache[current_context()].get(pvname, None)
 
 
-def _matching_cache_entries(pvname, chid=None):
-    "return all matching cache entries for a specific pvname, chid"
-    # TODO: This is as previously implemented - I'm not sure if it actually
-    # makes sense. Even if pvnames/chids are the same from different contexts,
-    # they are not _actually_ the same.
-    matching_pvnames = [
-        (context, cvals[pvname])
-        for context, cvals in _cache.items()
-        if pvname in cvals
-    ]
-    if chid is None:
-        return matching_pvnames
-    return [(context, entry)
-            for context, entry in matching_pvnames
-            if entry.chid == chid
-            ]
-
-
 def show_cache(print_out=True):
     """print out a listing of PVs in the current session to
     standard output.  Use the *print_out=False* option to be
@@ -657,27 +639,19 @@ def _onConnectionEvent(args):
     if dbr.PY64_WINDOWS:
         args = args.contents
 
-    ctx = current_context()
     conn = (args.op == dbr.OP_CONN_UP)
-
-    if ctx is None and len(_cache.keys()) > 0:
-        ctx = list(_cache.keys())[0]
 
     # search for PV in any context...
     pvname = name(args.chid)
-    chid = int(args.chid)
-    entries = _matching_cache_entries(pvname, None)
+    entry = get_cache(pvname)
 
     # logging.debug("ConnectionEvent %s/%i/%i " % (pvname, args.chid, conn))
     # print("ConnectionEvent %s/%i/%i " % (pvname, args.chid, conn))
-    if not entries:
-        entry = _CacheItem(chid=chid, pvname=pvname)
-        _cache[ctx][pvname] = entry
-        entries = [(ctx, entry)]
+    if entry is None:
+        entry = _CacheItem(chid=args.chid, pvname=pvname)
+        _cache[current_context()][pvname] = entry
 
-    # set connection time and run connection callbacks in all contexts
-    for context, entry in entries:
-        entry.run_connection_callbacks(conn=conn, timestamp=timestamp)
+    entry.run_connection_callbacks(conn=conn, timestamp=timestamp)
 
 
 ## get event handler:
@@ -735,8 +709,10 @@ def _onAccessRightsEvent(args):
 
     # Getting bunk result from ca.current_context on channel disconnect
     # Do this the long way...
-    for context, entry in _matching_cache_entries(pvname, chid):
+    entry = get_cache(pvname)
+    if entry is not None:
         entry.run_access_event_callbacks(ra, wa)
+
 
 # create global reference to these callbacks
 _CB_CONNECT = dbr.make_callback(_onConnectionEvent, dbr.connection_args)

--- a/epics/ca.py
+++ b/epics/ca.py
@@ -15,14 +15,16 @@ documentation here is developer documentation.
 import ctypes
 import ctypes.util
 
+import atexit
+import collections
 import functools
 import os
 import sys
+import threading
 import time
-from math import log10
-import atexit
 import warnings
-from threading import Thread
+
+from math import log10
 from pkg_resources import resource_filename
 
 from .utils import (STR2BYTES, BYTES2STR, NULLCHAR, NULLCHAR_2,
@@ -74,13 +76,8 @@ AUTOMONITOR_MAXLENGTH = 65536 # 16384
 DEFAULT_CONNECTION_TIMEOUT = 2.0
 
 ## Cache of existing channel IDs:
-#  pvname: {'chid':chid, 'conn': isConnected,
-#           'ts': ts_conn, 'callbacks': [ user_callback... ])
-#  isConnected   = True/False: if connected.
-#  ts_conn       = ts of last connection event or failed attempt.
-#  user_callback = one or more user functions to be called on
-#                  change (accumulated in the cache)
-_cache  = {}
+# Keyed on context, then on pv name (e.g., _cache[ctx][pvname])
+_cache = collections.defaultdict(dict)
 _namecache = {}
 
 # logging.basicConfig(filename='ca.log',level=logging.DEBUG)
@@ -112,6 +109,84 @@ class CASeverityException(Exception):
         self.msg = msg
     def __str__(self):
         return " %s returned '%s'" % (self.fcn, self.msg)
+
+
+class _CacheItem:
+    '''
+    The cache state for a single chid in a context.
+
+    This class itself is not thread-safe; it is expected that callers will use
+    the lock appropriately when modifying the state.
+
+    Attributes
+    ----------
+    lock : threading.RLock
+        A lock for modifying the state
+    conn : bool
+        The connection status
+    chid : ctypes.c_long
+        The channel ID
+    pvname : str
+        The PV name
+    ts : float
+        The connection timestamp (or last failed attempt)
+    failures : int
+        Number of failed connection attempts
+    requester_count : dict
+        The number of active requests (i.e., those that have yet to call
+        get_complete) associated with a single get request.
+        Keyed on the requested field type -> integer count
+    get_results : dict
+        Keyed on the requested field type -> requested value
+        This is cleared when no further requesters exist.
+    callbacks : list
+        One or more user functions to be called on change (accumulated in the
+        cache)
+    access_event_callbacks : list
+        One or more user functions to be called on change of access rights
+    '''
+
+    def __init__(self, chid, pvname, callbacks=None, ts=0):
+        self.lock = threading.RLock()
+        self.conn = False
+        self.chid = chid
+        self.pvname = pvname
+        self.ts = ts
+        self.failures = 0
+
+        self.requester_count = collections.defaultdict(lambda: 0)
+        self.get_results = collections.defaultdict(lambda: None)
+
+        if callbacks is None:
+            callbacks = []
+
+        self.callbacks = callbacks
+        self.access_event_callback = []
+
+    def __getitem__(self, key):
+        # back-compat
+        return getattr(self, key)
+
+    @property
+    def chid_int(self):
+        return _chid_to_int(self.chid)
+
+    def run_access_event_callbacks(self, ra, wa):
+        for callback in list(self.access_event_callback):
+            if callable(callback):
+                callback(ra, wa)
+
+    def run_connection_callbacks(self, conn, timestamp):
+        self.conn = conn
+        self.timestamp = timestamp
+        self.failures = 0
+
+        chid_int = self.chid_int
+        for callback in list(self.callbacks):
+            if callable(callback):
+                poll()
+                # print( ' ==> connection callback ', callback, conn)
+                callback(pvname=self.pvname, chid=chid_int, conn=self.conn)
 
 
 def _find_lib(inp_lib_name):
@@ -214,7 +289,7 @@ def initialize_libca():
     if 'EPICS_CA_MAX_ARRAY_BYTES' not in os.environ:
         os.environ['EPICS_CA_MAX_ARRAY_BYTES'] = "%i" %  2**24
 
-    global libca, initial_context, _cache
+    global libca, initial_context
 
     if os.name == 'nt':
         load_dll = ctypes.windll.LoadLibrary
@@ -278,7 +353,6 @@ def finalize_libca(maxtime=10.0):
 
     """
     global libca
-    global _cache
     if libca is None:
         return
     try:
@@ -287,10 +361,8 @@ def finalize_libca(maxtime=10.0):
         poll()
         for ctxid, ctx in _cache.items():
             for pvname, info in ctx.items():
-                try:
-                    clear_channel(info['chid'])
-                except KeyError:
-                    pass
+                if info.chid is not None:
+                    clear_channel(info.chid)
             ctx.clear()
         _cache.clear()
         flush_count = 0
@@ -305,9 +377,28 @@ def finalize_libca(maxtime=10.0):
         pass
     time.sleep(0.01)
 
+
 def get_cache(pvname):
     "return cache dictionary for a given pvname in the current context"
     return _cache[current_context()].get(pvname, None)
+
+
+def _matching_cache_entries(pvname, chid=None):
+    "return all matching cache entries for a specific pvname, chid"
+    # TODO: This is as previously implemented - I'm not sure if it actually
+    # makes sense. Even if pvnames/chids are the same from different contexts,
+    # they are not _actually_ the same.
+    matching_pvnames = [
+        (context, cvals[pvname])
+        for context, cvals in _cache.items()
+        if pvname in cvals
+    ]
+    if chid is None:
+        return matching_pvnames
+    return [(context, entry)
+            for context, entry in matching_pvnames
+            if entry.chid == chid
+            ]
 
 
 def show_cache(print_out=True):
@@ -315,13 +406,12 @@ def show_cache(print_out=True):
     standard output.  Use the *print_out=False* option to be
     returned the listing instead of having it printed out.
     """
-    global _cache
     out = []
     out.append('#  PVName        ChannelID/Context Connected?')
     out.append('#--------------------------------------------')
     for context, context_chids in  list(_cache.items()):
         for vname, val in list(context_chids.items()):
-            chid = val['chid']
+            chid = val.chid
             if len(vname) < 15:
                 vname = (vname + ' '*15)[:15]
             out.append(" %s %s/%s  %s" % (vname, repr(chid),
@@ -342,7 +432,6 @@ def clear_cache():
     """
 
     # Clear global state variables
-    global _cache
     _cache.clear()
     _put_done.clear()
 
@@ -535,56 +624,34 @@ def _onMonitorEvent(args):
 def _onConnectionEvent(args):
     """set flag in cache holding whteher channel is
     connected. if provided, run a user-function"""
+    timestamp = time.time()
+
     # for 64-bit python on Windows!
     if dbr.PY64_WINDOWS:
         args = args.contents
 
     ctx = current_context()
     conn = (args.op == dbr.OP_CONN_UP)
-    global _cache
 
     if ctx is None and len(_cache.keys()) > 0:
         ctx = list(_cache.keys())[0]
-    if ctx not in _cache:
-        _cache[ctx] = {}
 
     # search for PV in any context...
-    pv_found = False
-    for context in _cache:
-        pvname = name(args.chid)
-
-        if pvname in _cache[context]:
-            pv_found = True
-            break
+    pvname = name(args.chid)
+    chid = int(args.chid)
+    entries = _matching_cache_entries(pvname, None)
 
     # logging.debug("ConnectionEvent %s/%i/%i " % (pvname, args.chid, conn))
     # print("ConnectionEvent %s/%i/%i " % (pvname, args.chid, conn))
-    if not pv_found:
-        _cache[ctx][pvname] = {'conn':False, 'chid': args.chid,
-                               'ts':0, 'failures':0, 'value': None,
-                               'callbacks': []}
+    if not entries:
+        entry = _CacheItem(chid=chid, pvname=pvname)
+        _cache[ctx][pvname] = entry
+        entries = [(ctx, entry)]
 
-    # set connection time, run connection callbacks
-    # in all contexts
-    for context, cvals in _cache.items():
-        if pvname in cvals:
-            entry = cvals[pvname]
-            ichid = entry['chid']
-            if isinstance(entry['chid'], dbr.chid_t):
-                ichid = entry['chid'].value
+    # set connection time and run connection callbacks in all contexts
+    for context, entry in entries:
+        entry.run_connection_callbacks(conn=conn, timestamp=timestamp)
 
-            if int(ichid) == int(args.chid):
-                chid = args.chid
-                entry.update({'chid': chid, 'conn': conn,
-                              'ts': time.time(), 'failures': 0})
-                for callback in entry.get('callbacks', []):
-                    poll()
-                    if hasattr(callback, '__call__'):
-                        # print( ' ==> connection callback ', callback, conn)
-                        callback(pvname=pvname, chid=chid, conn=conn)
-    #print('Connection done')
-
-    return
 
 ## get event handler:
 def _onGetEvent(args, **kws):
@@ -597,14 +664,18 @@ def _onGetEvent(args, **kws):
     # print("GET EVENT: chid, user ", args.chid, args.usr)
     # print("GET EVENT: type, count ", args.type, args.count)
     # print("GET EVENT: status ",  args.status, dbr.ECA_NORMAL)
-    global _cache
+    entry = get_cache(name(args.chid))
+
     if args.status != dbr.ECA_NORMAL:
+        warnings.warn('Get failed for chid %d' % args.chid)
         return
 
     if dbr.IRON_PYTHON:
-        get_cache(name(args.chid))[args.usr.value] = (dbr.cast_args(args))
+        ftype = args.usr.value
+        entry.get_results[ftype] = dbr.cast_args(args)
     else:
-        get_cache(name(args.chid))[args.usr] = memcopy(dbr.cast_args(args))
+        ftype = args.usr
+        entry.get_results[ftype] = memcopy(dbr.cast_args(args))
 
 
 ## put event handler:
@@ -629,24 +700,18 @@ def _onPutEvent(args, **kwds):
 
 def _onAccessRightsEvent(args):
     # for 64-bit python on Windows!
-    global _cache
     if dbr.PY64_WINDOWS:
         args = args.contents
 
     chid = args.chid
+    pvname = name(chid)
     ra = bool(args.read_access)
     wa = bool(args.write_access)
 
     # Getting bunk result from ca.current_context on channel disconnect
     # Do this the long way...
-    for ctx in _cache.values():
-        pvname = name(chid)
-        if pvname in ctx:
-            ch = ctx[pvname]
-            if 'access_event_callback' in ch:
-                for callback in ch['access_event_callback']:
-                    if callable(callback):
-                        callback(ra, wa)
+    for context, entry in _matching_cache_entries(pvname, chid):
+        entry.run_access_event_callbacks(ra, wa)
 
 # create global reference to these callbacks
 _CB_CONNECT = dbr.make_callback(_onConnectionEvent, dbr.connection_args)
@@ -667,11 +732,7 @@ def context_create(ctx=None):
     "create a context. if argument is None, use PREEMPTIVE_CALLBACK"
     if ctx is None:
         ctx = {False:0, True:1}[PREEMPTIVE_CALLBACK]
-    ret = libca.ca_context_create(ctx)
-    new_ctx = current_context()
-    if new_ctx and new_ctx not in _cache:
-        _cache[new_ctx] = {}
-    return ret
+    return libca.ca_context_create(ctx)
 
 
 def create_context(ctx=None):
@@ -696,12 +757,11 @@ def create_context(ctx=None):
 @withCA
 def context_destroy():
     "destroy current context"
-    global _cache
     ctx = current_context()
     ret = libca.ca_context_destroy()
-    if ctx in _cache:
-        _cache[ctx].clear()
-        _cache.pop(ctx)
+    ctx_cache = _cache.pop(ctx, None)
+    if ctx_cache is not None:
+        ctx_cache.clear()
     return ret
 
 def destroy_context():
@@ -865,40 +925,36 @@ def create_channel(pvname, connect=False, auto_cb=True, callback=None):
     # callback that is run -- the callack here is stored in the _cache
     # and called by _onConnectionEvent.
     pvn = STR2BYTES(pvname)
-    ctx = current_context()
-    global _cache
-    if ctx not in _cache:
-        _cache[ctx] = {}
-    if pvname not in _cache[ctx]: # new PV for this context
-        entry = {'conn':False,  'chid': None,
-                 'ts': 0,  'failures':0, 'value': None,
-                 'callbacks': [ callback ]}
+    ctx_cache = _cache[current_context()]
+    try:
+        entry = ctx_cache[pvname]
+    except KeyError:
+        # New entry for this context
+        entry = _CacheItem(chid=None, pvname=pvname, callbacks=[callback])
+        ctx_cache[pvname] = entry
         # logging.debug("Create Channel %s " % pvname)
-        _cache[ctx][pvname] = entry
     else:
-        entry = _cache[ctx][pvname]
-        if not entry['conn'] and callback is not None: # pending connection
-            _cache[ctx][pvname]['callbacks'].append(callback)
-        elif (hasattr(callback, '__call__') and
-              not callback in entry['callbacks']):
-            entry['callbacks'].append(callback)
-            callback(chid=entry['chid'], pvname=pvname, conn=entry['conn'])
+        if not entry.conn and callback is not None: # pending connection
+            entry.callbacks.append(callback)
+        elif callable(callback) and callback not in entry.callbacks:
+            entry.callbacks.append(callback)
+            callback(chid=_chid_to_int(entry.chid), pvname=pvname,
+                     conn=entry.conn)
+
     conncb = 0
     if auto_cb:
         conncb = _CB_CONNECT
-    if entry.get('chid', None) is not None:
-        # already have or waiting on a chid
-        chid = _cache[ctx][pvname]['chid']
-    else:
-        entry['chid'] = dbr.chid_t()
-        ret = libca.ca_create_channel(ctypes.c_char_p(pvn), conncb, 0, 0,
-                                      ctypes.byref(entry['chid']))
-        PySEVCHK('create_channel', ret)
-        chid = entry['chid']
-    chid_key = chid
-    if isinstance(chid_key, dbr.chid_t):
-        chid_key = chid.value
-    _namecache[chid_key] = BYTES2STR(pvn)
+
+    with entry.lock:
+        chid = entry.chid
+        if chid is None:
+            chid = dbr.chid_t()
+            entry.chid = chid
+            ret = libca.ca_create_channel(ctypes.c_char_p(pvn), conncb, 0, 0,
+                                          ctypes.byref(chid))
+            PySEVCHK('create_channel', ret)
+
+    _namecache[_chid_to_int(chid)] = BYTES2STR(pvn)
     if connect:
         connect_channel(chid)
     return chid
@@ -949,10 +1005,6 @@ def connect_channel(chid, timeout=None, verbose=False):
         start_time = time.time()
         ctx = current_context()
         pvname = name(chid)
-        global _cache
-        if ctx not in _cache:
-            _cache[ctx] = {}
-
         if timeout is None:
             timeout = DEFAULT_CONNECTION_TIMEOUT
 
@@ -960,38 +1012,53 @@ def connect_channel(chid, timeout=None, verbose=False):
             poll()
             conn = (state(chid) == dbr.CS_CONN)
         if not conn:
-            _cache[ctx][pvname]['ts'] = time.time()
-            _cache[ctx][pvname]['failures'] += 1
+            entry = _cache[ctx][pvname]
+            with entry.lock:
+                entry.ts = time.time()
+                entry.failures += 1
     return conn
 
 # functions with very light wrappings:
 @withCHID
 def replace_access_rights_event(chid, callback=None):
-    global _cache
-
-    ctx = current_context()
-    ch = _cache[ctx][name(chid)]
-    if 'access_event_callback' not in ch:
-        ch.update({'access_event_callback': list()})
+    ch = get_cache(name(chid))
 
     if callback is not None:
-        ch['access_event_callback'].append(callback)
+        ch.access_event_callback.append(callback)
 
     ret = libca.ca_replace_access_rights_event(chid, _CB_ACCESS)
     PySEVCHK('replace_access_rights_event', ret)
 
+def _chid_to_int(chid):
+    '''
+    Return the integer representation of a chid
+
+    Parameters
+    ----------
+    chid : ctypes.c_long, int
+
+    Returns
+    -------
+    chid : int
+    '''
+    if hasattr(chid, 'value'):
+        return int(chid.value)
+    return chid
+
+
 @withCHID
 def name(chid):
     "return PV name for channel name"
-    global _namecache
     # sys.stdout.write("NAME %s %s\n" % (repr(chid), repr(chid.value in _namecache)))
     # sys.stdout.flush()
 
-    if chid.value in _namecache:
-        val = _namecache[chid.value]
-    else:
-        val = _namecache[chid.value] = BYTES2STR(libca.ca_name(chid))
-    return val
+    chid = _chid_to_int(chid)
+    try:
+        return _namecache[chid]
+    except KeyError:
+        name = BYTES2STR(libca.ca_name(chid))
+        _namecache[chid] = name
+        return name
 
 @withCHID
 def host_name(chid):
@@ -1235,8 +1302,6 @@ def get_with_metadata(chid, ftype=None, count=None, wait=True, timeout=None,
     --------
     See :func:`get` for additional usage notes.
     """
-    global _cache
-
     if ftype is None:
         ftype = field_type(chid)
     if ftype in (None, -1):
@@ -1249,15 +1314,18 @@ def get_with_metadata(chid, ftype=None, count=None, wait=True, timeout=None,
     else:
         count = min(count, element_count(chid))
 
-    ncache = _cache[current_context()][name(chid)]
+    entry = get_cache(name(chid))
     # implementation note: cached value of
     #   None        implies no value, no expected callback
     #   GET_PENDING implies no value yet, callback expected.
-    if ncache.get('value', None) is None:
-        ncache['value'] = GET_PENDING
-        ret = libca.ca_array_get_callback(ftype, count, chid, _CB_GET,
-                                          ctypes.py_object('value'))
-        PySEVCHK('get', ret)
+    with entry.lock:
+        entry.requester_count[ftype] += 1
+        request_pending = entry.get_results[ftype] is GET_PENDING
+        if not request_pending:
+            entry.get_results[ftype] = GET_PENDING
+            ret = libca.ca_array_get_callback(
+                ftype, count, chid, _CB_GET, ctypes.py_object(ftype))
+            PySEVCHK('get', ret)
 
     if wait:
         return get_complete_with_metadata(chid, count=count, ftype=ftype,
@@ -1368,8 +1436,6 @@ def get_complete_with_metadata(chid, ftype=None, count=None, timeout=None,
     --------
     See :func:`get_complete` for additional usage notes.
     """
-    global _cache
-
     if ftype is None:
         ftype = field_type(chid)
     if count is None:
@@ -1377,24 +1443,34 @@ def get_complete_with_metadata(chid, ftype=None, count=None, timeout=None,
     else:
         count = min(count, element_count(chid))
 
-    ncache = _cache[current_context()][name(chid)]
-    if ncache['value'] is None:
+    entry = get_cache(name(chid))
+    if entry.get_results[ftype] is None:
+        warnings.warn('get_complete without initial get() call')
         return None
 
     t0 = time.time()
     if timeout is None:
         timeout = 1.0 + log10(max(1, count))
-    while ncache['value'] is GET_PENDING:
+
+    while True:
         poll()
+        full_value = entry.get_results[ftype]
+        if full_value is not GET_PENDING:
+            break
+
         if time.time()-t0 > timeout:
             msg = "ca.get('%s') timed out after %.2f seconds."
             warnings.warn(msg % (name(chid), timeout))
             return None
-    # print("Get Complete> Unpack ", ncache['value'], count, ftype)
-    full_value = ncache['value']
-    if full_value is None:
-        return
 
+    # print("Get Complete> Unpack ", ncache['value'], count, ftype)
+    with entry.lock:
+        entry.requester_count[ftype] -= 1
+        if entry.requester_count[ftype] == 0:
+            entry.get_results[ftype] = None
+
+    # NOTE: unpacking happens for each requester; this could potentially be put
+    # in the get callback itself. (different downside there...)
     extended_data, _ = full_value
     metadata = _unpack_metadata(ftype=ftype, dbr_value=extended_data)
     val = _unpack(chid, full_value, count=count,
@@ -1407,7 +1483,6 @@ def get_complete_with_metadata(chid, ftype=None, count=None, timeout=None,
         val = numpy.ctypeslib.as_array(memcopy(val))
 
     # value retrieved, clear cached value
-    ncache['value'] = None
     metadata['value'] = val
     return metadata
 
@@ -1865,11 +1940,11 @@ def sg_put(gid, chid, value):
     # poll()
     return ret
 
-class CAThread(Thread):
+class CAThread(threading.Thread):
     """
     Sub-class of threading.Thread to ensure that the
     initial CA context is used.
     """
     def run(self):
         use_initial_context()
-        Thread.run(self)
+        threading.Thread.run(self)

--- a/epics/ca.py
+++ b/epics/ca.py
@@ -309,6 +309,7 @@ def get_cache(pvname):
     "return cache dictionary for a given pvname in the current context"
     return _cache[current_context()].get(pvname, None)
 
+
 def show_cache(print_out=True):
     """print out a listing of PVs in the current session to
     standard output.  Use the *print_out=False* option to be
@@ -1623,36 +1624,12 @@ def get_ctrlvars(chid, timeout=5.0, warn=True):
     enum_strs will be a list of strings for the names of ENUM states.
 
     """
-    global _cache
-
     ftype = promote_type(chid, use_ctrl=True)
-    ncache = _cache[current_context()][name(chid)]
-    if ncache.get('ctrl_value', None) is None:
-        ncache['ctrl_value'] = GET_PENDING
-        ret = libca.ca_array_get_callback(ftype, 1, chid, _CB_GET,
-                                          ctypes.py_object('ctrl_value'))
-
-        PySEVCHK('get_ctrlvars', ret)
-
-    if ncache.get('ctrl_value', None) is None:
-        return {}
-
-    t0 = time.time()
-    while ncache['ctrl_value'] is GET_PENDING:
-        poll()
-        if time.time()-t0 > timeout:
-            if warn:
-                msg = "ca.get_ctrlvars('%s') timed out after %.2f seconds."
-                warnings.warn(msg % (name(chid), timeout))
-            return {}
-    try:
-        extended_data = ncache['ctrl_value'][0]
-    except TypeError:
-        return {}
-
-    out = _unpack_metadata(ftype=ftype, dbr_value=extended_data)
-    ncache['ctrl_value'] = None
-    return out
+    metadata = get_with_metadata(chid, ftype=ftype, count=1, timeout=timeout,
+                                 wait=True)
+    # Ignore the value returned:
+    metadata.pop('value', None)
+    return metadata
 
 
 @withCHID
@@ -1660,38 +1637,12 @@ def get_timevars(chid, timeout=5.0, warn=True):
     """returns a dictionary of TIME fields for a Channel.
     This will contain keys of  *status*, *severity*, and *timestamp*.
     """
-    global _cache
-
     ftype = promote_type(chid, use_time=True)
-    ncache = _cache[current_context()][name(chid)]
-    if ncache.get('time_value', None) is None:
-        ncache['time_value'] = GET_PENDING
-        ret = libca.ca_array_get_callback(ftype, 1, chid, _CB_GET,
-                                          ctypes.py_object('time_value'))
-
-        PySEVCHK('get_timevars', ret)
-
-    out = {}
-    if ncache.get('time_value', None) is None:
-        return out
-
-    t0 = time.time()
-    while ncache['time_value'] is GET_PENDING:
-        poll()
-        if time.time()-t0 > timeout:
-            if warn:
-                msg = "ca.get_timevars('%s') timed out after %.2f seconds."
-                warnings.warn(msg % (name(chid), timeout))
-            return {}
-
-    try:
-        extended_data = ncache['time_value'][0]
-    except TypeError:
-        return {}
-
-    out = _unpack_metadata(ftype=ftype, dbr_value=extended_data)
-    ncache['time_value'] = None
-    return out
+    metadata = get_with_metadata(chid, ftype=ftype, count=1, timeout=timeout,
+                                 wait=True)
+    # Ignore the value returned:
+    metadata.pop('value', None)
+    return metadata
 
 
 def get_timestamp(chid):

--- a/epics/ca.py
+++ b/epics/ca.py
@@ -1155,7 +1155,7 @@ def promote_fieldtype(ftype, use_time=False, use_ctrl=False):
 
 def _unpack(chid, data, count=None, ftype=None, as_numpy=True):
     """unpacks raw data for a Channel ID `chid` returned by libca functions
-    including `ca_get_array_callback` or subscription callback, and returns
+    including `ca_array_get_callback` or subscription callback, and returns
     the corresponding Python data
 
     Normally, users are not expected to need to access this function, but

--- a/epics/ca.py
+++ b/epics/ca.py
@@ -1322,7 +1322,8 @@ def get_with_metadata(chid, ftype=None, count=None, wait=True, timeout=None,
     #   None        implies no value, no expected callback
     #   GET_PENDING implies no value yet, callback expected.
     with entry.lock:
-        if entry.get_results[ftype][0] is not GET_PENDING:
+        last_get, = entry.get_results[ftype]
+        if last_get is not GET_PENDING:
             entry.get_results[ftype] = [GET_PENDING]
             ret = libca.ca_array_get_callback(
                 ftype, count, chid, _CB_GET, ctypes.py_object(ftype))

--- a/epics/ca.py
+++ b/epics/ca.py
@@ -83,13 +83,21 @@ _put_completes = []
 
 # logging.basicConfig(filename='ca.log',level=logging.DEBUG)
 
-# get a unique python value that cannot be a value held by an
-# actual PV to signal "Get is incomplete, awaiting callback"
-class Empty:
-    """used to create a unique python value that cannot be
-    held as an actual PV value"""
-    pass
-GET_PENDING = Empty()
+class _GetPending:
+    """
+    _GetPending is used to create a unique python value that cannot be held as
+    an actual PV value.
+
+    A unique python value that cannot be a value held by an actual PV to signal
+    "Get is incomplete, awaiting callback"
+    """
+    def __repr__(self):
+        return 'GET_PENDING'
+
+
+Empty = _GetPending  # back-compat
+GET_PENDING = _GetPending()
+
 
 class ChannelAccessException(Exception):
     """Channel Access Exception: General Errors"""

--- a/epics/ca.py
+++ b/epics/ca.py
@@ -706,7 +706,9 @@ def _onGetEvent(args, **kws):
     else:
         result = memcopy(dbr.cast_args(args))
 
-    entry.get_results[ftype] = result
+    with entry.lock:
+        entry.get_results[ftype] = result
+
 
 ## put event handler:
 def _onPutEvent(args, **kwds):

--- a/epics/ca.py
+++ b/epics/ca.py
@@ -15,11 +15,11 @@ documentation here is developer documentation.
 import ctypes
 import ctypes.util
 
+import functools
 import os
 import sys
 import time
-import logging
-from  math import log10
+from math import log10
 import atexit
 import warnings
 from threading import Thread
@@ -376,15 +376,13 @@ def withCA(fcn):
     Note that CA functions that take a Channel ID (chid) as an
     argument are  NOT wrapped by this: to get a chid, the
     library must have been initialized already."""
+    @functools.wraps(fcn)
     def wrapper(*args, **kwds):
         "withCA wrapper"
         global libca
         if libca is None:
             initialize_libca()
         return fcn(*args, **kwds)
-    wrapper.__doc__ = fcn.__doc__
-    wrapper.__name__ = fcn.__name__
-    wrapper.__dict__.update(fcn.__dict__)
     return wrapper
 
 def withCHID(fcn):
@@ -396,6 +394,7 @@ def withCHID(fcn):
     # It may be worth making a chid class (which could hold connection
     # data of _cache) that could be tested here.  For now, that
     # seems slightly 'not low-level' for this module.
+    @functools.wraps(fcn)
     def wrapper(*args, **kwds):
         "withCHID wrapper"
         if len(args)>0:
@@ -409,9 +408,6 @@ def withCHID(fcn):
                 raise ChannelAccessException(msg)
 
         return fcn(*args, **kwds)
-    wrapper.__doc__ = fcn.__doc__
-    wrapper.__name__ = fcn.__name__
-    wrapper.__dict__.update(fcn.__dict__)
     return wrapper
 
 
@@ -421,6 +417,7 @@ def withConnectedCHID(fcn):
     robust, and will try to make sure a ``chid`` is actually connected
     before calling the decorated function.
     """
+    @functools.wraps(fcn)
     def wrapper(*args, **kwds):
         "withConnectedCHID wrapper"
         if len(args)>0:
@@ -440,15 +437,13 @@ def withConnectedCHID(fcn):
                                                 name(chid), timeout))
 
         return fcn(*args, **kwds)
-    wrapper.__doc__ = fcn.__doc__
-    wrapper.__name__ = fcn.__name__
-    wrapper.__dict__.update(fcn.__dict__)
     return wrapper
 
 def withMaybeConnectedCHID(fcn):
     """decorator to **try** to ensure that the first argument of a function
     is a connected Channel ID, ``chid``.
     """
+    @functools.wraps(fcn)
     def wrapper(*args, **kwds):
         "withMaybeConnectedCHID wrapper"
         if len(args)>0:
@@ -463,22 +458,17 @@ def withMaybeConnectedCHID(fcn):
                 timeout = kwds.get('timeout', DEFAULT_CONNECTION_TIMEOUT)
                 connect_channel(chid, timeout=timeout)
         return fcn(*args, **kwds)
-    wrapper.__doc__ = fcn.__doc__
-    wrapper.__name__ = fcn.__name__
-    wrapper.__dict__.update(fcn.__dict__)
     return wrapper
 
 def withInitialContext(fcn):
     """decorator to ensure that the wrapped function uses the
     initial threading context created at initialization of CA
     """
+    @functools.wraps(fcn)
     def wrapper(*args, **kwds):
         "withInitialContext wrapper"
         use_initial_context()
         return fcn(*args, **kwds)
-    wrapper.__doc__ = fcn.__doc__
-    wrapper.__name__ = fcn.__name__
-    wrapper.__dict__.update(fcn.__dict__)
     return wrapper
 
 def PySEVCHK(func_name, status, expected=dbr.ECA_NORMAL):
@@ -500,13 +490,11 @@ def withSEVCHK(fcn):
     function whose return value is from a corresponding libca function
     and whose return value should be ``dbr.ECA_NORMAL``.
     """
+    @functools.wraps(fcn)
     def wrapper(*args, **kwds):
         "withSEVCHK wrapper"
         status = fcn(*args, **kwds)
         return PySEVCHK( fcn.__name__, status)
-    wrapper.__doc__ = fcn.__doc__
-    wrapper.__name__ = fcn.__name__
-    wrapper.__dict__.update(fcn.__dict__)
     return wrapper
 
 ##

--- a/epics/ca.py
+++ b/epics/ca.py
@@ -99,6 +99,14 @@ class ChannelAccessException(Exception):
         if type_ is not None:
             sys.excepthook(type_, value, traceback)
 
+class ChannelAccessGetFailure(Exception):
+    """Channel Access Exception: _onGetEvent != ECA_NORMAL"""
+    def __init__(self, message, chid, status):
+        super(ChannelAccessGetFailure, self).__init__(message)
+        self.chid = chid
+        self.status = status
+
+
 class CASeverityException(Exception):
     """Channel Access Severity Check Exception:
     PySEVCHK got unexpected return value"""
@@ -684,18 +692,21 @@ def _onGetEvent(args, **kws):
     # print("GET EVENT: type, count ", args.type, args.count)
     # print("GET EVENT: status ",  args.status, dbr.ECA_NORMAL)
     entry = get_cache(name(args.chid))
+    ftype = (args.usr.value if dbr.IRON_PYTHON
+             else args.usr)
 
     if args.status != dbr.ECA_NORMAL:
-        warnings.warn('Get failed for chid %d' % args.chid)
-        return
-
-    if dbr.IRON_PYTHON:
-        ftype = args.usr.value
-        entry.get_results[ftype] = dbr.cast_args(args)
+        result = ChannelAccessGetFailure(
+            'Get failed; status code: %d' % args.status,
+            chid=args.chid,
+            status=args.status
+        )
+    elif dbr.IRON_PYTHON:
+        result = dbr.cast_args(args)
     else:
-        ftype = args.usr
-        entry.get_results[ftype] = memcopy(dbr.cast_args(args))
+        result = memcopy(dbr.cast_args(args))
 
+    entry.get_results[ftype] = result
 
 ## put event handler:
 def _onPutEvent(args, **kwds):
@@ -1479,6 +1490,10 @@ def get_complete_with_metadata(chid, ftype=None, count=None, timeout=None,
         entry.requester_count[ftype] -= 1
         if entry.requester_count[ftype] == 0:
             entry.get_results[ftype] = None
+
+    if isinstance(full_value, Exception):
+        get_failure_reason = full_value
+        raise get_failure_reason
 
     # NOTE: unpacking happens for each requester; this could potentially be put
     # in the get callback itself. (different downside there...)

--- a/epics/pv.py
+++ b/epics/pv.py
@@ -319,6 +319,9 @@ class PV(object):
         0
         >>> get_pv('13BMD:m1.DIR').get(as_string=True)
         'Pos'
+
+        If the Channel Access status code sent by the IOC indicates a failure,
+        this method will raise the exception ChannelAccessGetFailure.
         """
         data = self.get_with_metadata(count=count, as_string=as_string,
                                       as_numpy=as_numpy, timeout=timeout,

--- a/epics/pv.py
+++ b/epics/pv.py
@@ -394,12 +394,12 @@ class PV(object):
             if count is None and self._args['count']!=self._args['nelm']:
                 count = self._args['count']
 
-            ca_get = ca.get_with_metadata
-            if ca.get_cache(self.pvname)['value'] is not None:
-                ca_get = ca.get_complete_with_metadata
-
-            md = ca_get(self.chid, ftype=ftype, count=count,
-                        timeout=timeout, as_numpy=as_numpy)
+            # ca.get_with_metadata will handle multiple requests for the same
+            # PV internally, so there is no need to change between
+            # `get_with_metadata` and `get_complete_with_metadata` here.
+            md = ca.get_with_metadata(
+                self.chid, ftype=ftype, count=count, timeout=timeout,
+                as_numpy=as_numpy)
             if md is None:
                 # Get failed. Indicate with a `None` as the return value
                 return

--- a/epics/pv.py
+++ b/epics/pv.py
@@ -485,12 +485,12 @@ class PV(object):
             if callback is not None:
                 callback(pvname=pvname, **kws)
 
-        if callback and not use_complete:
-            use_complete = True
+        if use_complete:
+            self._put_complete = False
 
         return ca.put(self.chid, value,
                       wait=wait, timeout=timeout,
-                      callback=_put_callback if use_complete else None,
+                      callback=_put_callback if use_complete or callback else None,
                       callback_data=callback_data)
 
     def _set_charval(self, val, call_ca=True, force_long_string=False):

--- a/tests/ca_unittest.py
+++ b/tests/ca_unittest.py
@@ -439,6 +439,11 @@ class CA_BasicTests(unittest.TestCase):
         self.assertEqual(conv, char_val)
 
 
+def test_smoke_show_cache():
+    ca.show_cache(print_out=True)
+    assert ca.show_cache(print_out=False) is not None
+
+
 if __name__ == '__main__':
     suite = unittest.TestLoader().loadTestsFromTestCase( CA_BasicTests)
     unittest.TextTestRunner(verbosity=1).run(suite)

--- a/tests/test_threading.py
+++ b/tests/test_threading.py
@@ -1,5 +1,3 @@
-import pytest
-
 import epics
 import threading
 import pvnames

--- a/tests/test_threading.py
+++ b/tests/test_threading.py
@@ -71,33 +71,3 @@ def test_pv_from_main():
     t.join()
 
     assert len(result) and result[0] is not None
-
-
-@pytest.mark.parametrize('num_threads', [1, 200])
-def test_pv_multithreaded_get(num_threads):
-    def thread(thread_idx):
-        result[thread_idx] = (pv.get(),
-                              pv.get_with_metadata(form='ctrl')['value'],
-                              pv.get_with_metadata(form='time')['value'],
-                              )
-
-    result = {}
-    epics.ca.use_initial_context()
-    pv = epics.PV(pvnames.double_pv2)
-
-    threads = [epics.ca.CAThread(target=thread,
-                                 args=(i, ))
-               for i in range(num_threads)]
-
-    for thread in threads:
-        thread.start()
-    for thread in threads:
-        thread.join()
-
-    assert len(result) == num_threads
-    print(result)
-    values = set(result.values())
-    assert len(values) == 1
-
-    value, = values
-    assert value is not None

--- a/tests/test_threading.py
+++ b/tests/test_threading.py
@@ -73,7 +73,7 @@ def test_pv_from_main():
     assert len(result) and result[0] is not None
 
 
-@pytest.mark.parametrize('num_threads', [1, 100])
+@pytest.mark.parametrize('num_threads', [1, 200])
 def test_pv_multithreaded_get(num_threads):
     def thread(thread_idx):
         result[thread_idx] = (pv.get(),


### PR DESCRIPTION
(This PR is on the larger side - I can break it up if some parts are more controversial than others)

Added tests
-------------
This PR adds two tests that fail on master:
  1. ~pv_unittest.test_multithreaded_get
    This fails on master due to race conditions with the per-context cache~ pulled out into #150 
  2. ~pv_unittest.test_multithreaded_put_complete
    This fails on master since put_completes are keyed solely on `pvname` and there is no guarantee that a libca callback is corresponding to the specific user request~ pulled out into #149 

Fixes as implemented in this PR
--------------------------------

* ~Fix for (2): Changing the `put_complete` callbacks to be unique for each request - clients can now be sure that the respective call was actually completed~ pulled out into #149 
* Fix for (1): Making it such that simultaneous get requests can share the result. In master, this is a race to "who gets the result first", with the rest failing somewhere in `get_complete` (or receiving `None`)
    * The logic is now as follows: 
        * If there is an in-process get request for a specific field type (e.g., DBR_CTRL_INT) for a PV, other callers to `get()` with those same parameters will share the result and not duplicate the `libca` call. 
    * `get()` and `get_complete()` are two separate calls in pyepics. That means that in-between a call to `get()` and `get_complete()` on the user-side, it's possible that one or more duplicate get requests may have happened in separate threads. The end result would be that each call to `get_complete()` would get the latest value, and not necessarily the one that was in-flight when `get()` itself was called. I don't see an obvious way around this with the current API, but I don't necessarily think it's much of an issue, either.
    * There is a (mostly) minimal set of locking in place to keep track of these requests. 
    * Now, the codebase is more rigorous about the per-context cache bookkeeping
        * Adds a `_CacheItem` class that handles some of this. It keeps back-compat with `__getitem__` - but really clients should _not_ be touching the cache at all.

Additional issue and fix
---------------------------
`ca.get()` can fail and not return _any_ result to the user, ending in a timeout condition. This happens due to the check in `_onGetEvent`: https://github.com/pyepics/pyepics/blob/7fe180e0ab857f8189b4e1b048608235ac45b045/epics/ca.py#L613

This is resolved in this PR with the exception status propagating back to the user. This is a slight API break - errors that used to be masked as timeouts will now raise `ChannelAccessGetFailure`.

Miscellaneous fixes
--------------------
* ~Use `functools.wraps()` where needed~ - pulled out into #148 
* Tweak `GET_PENDING` to have a nice repr
* Use `defaultdict` to remove a bunch of `if ca.current_context() not in _cache` checks
* Access rights, connection callbacks were being run for all contexts
    * That did not make sense to me, and it is not present here. If I misunderstood that, we should revisit this.
* Refactors `get_timevars`, `get_ctrlvars` using `get_with_metadata`. All `get_*()`-related functions are now routed through this function only.

Overall
--------
This is a rather big change under the hood and should be reviewed/tested carefully. The implementation details are all negotiable.