### PR TITLE
REF: Add and fix test pv_unittest.test_multithreaded_put_complete

### DIFF
--- a/epics/ca.py
+++ b/epics/ca.py
@@ -82,11 +82,11 @@ DEFAULT_CONNECTION_TIMEOUT = 2.0
 #                  change (accumulated in the cache)
 _cache  = {}
 _namecache = {}
+
+# Puts with completion in progress:
 _put_completes = []
 
 # logging.basicConfig(filename='ca.log',level=logging.DEBUG)
-## Cache of pvs waiting for put to be done.
-_put_done =  {}
 
 # get a unique python value that cannot be a value held by an
 # actual PV to signal "Get is incomplete, awaiting callback"
@@ -344,7 +344,6 @@ def clear_cache():
     # Clear global state variables
     global _cache
     _cache.clear()
-    _put_done.clear()
 
     # Clear the cache of PVs used by epics.caget()-like functions
     from . import pv

--- a/epics/pv.py
+++ b/epics/pv.py
@@ -475,16 +475,19 @@ class PV(object):
                     if val == value:
                         value = ival
                         break
-        if use_complete and callback is None:
-            callback = self.__putCallbackStub
+
+        def _put_callback(pvname=None, **kws):
+            self._put_complete = True
+            if callback is not None:
+                callback(pvname=pvname, **kws)
+
+        if use_complete:
+            self._put_complete = False
+
         return ca.put(self.chid, value,
                       wait=wait, timeout=timeout,
-                      callback=callback,
+                      callback=_put_callback if use_complete or callback else None,
                       callback_data=callback_data)
-
-    def __putCallbackStub(self, pvname=None, **kws):
-        "null put-calback, so that the put_complete attribute is valid"
-        pass
 
     def _set_charval(self, val, call_ca=True, force_long_string=False):
         """ sets the character representation of the value.
@@ -890,11 +893,8 @@ class PV(object):
 
     @property
     def put_complete(self):
-        "returns True if a put-with-wait has completed"
-        putdone_data = ca._put_done.get(self.pvname, None)
-        if putdone_data is not None:
-            return putdone_data[0]
-        return True
+        "returns True if the last put-with-wait has completed"
+        return self._put_complete
 
     def __repr__(self):
         "string representation"

--- a/epics/pv.py
+++ b/epics/pv.py
@@ -127,6 +127,7 @@ class PV(object):
             self.access_callbacks = [access_callback]
 
         self.callbacks  = {}
+        self._put_complete = None
         self._monref = None  # holder of data returned from create_subscription
         self._conn_started = False
         if isinstance(callback, (tuple, list)):
@@ -481,8 +482,9 @@ class PV(object):
             if callback is not None:
                 callback(pvname=pvname, **kws)
 
-        if use_complete:
-            self._put_complete = False
+        self._put_complete = (False
+                              if use_complete
+                              else None)
 
         return ca.put(self.chid, value,
                       wait=wait, timeout=timeout,


### PR DESCRIPTION
Adds a test `pv_unittest.test_multithreaded_put_complete` which fails on master since put_completes are keyed solely on pvname (irrespective of context or anything else). There is no guarantee that the callback received corresponds to any specific user request.

This issue could be potentially seen in single-threaded cases, but the included test is done with many threads to provide some degree of certainty that it's doing what is expected.

My notes from the other PR this was separated from:
> For the put-with-callback, the exact response of the IOC is not our (library) concern. It's important to split up the client and server's role in this case. The logic is something like the following for a single request: "client request A was made. Did request A finish according to the IOC?" The current master has no issues with that scenario. For multiple requests, whether from different threads or even at different points in the same function: "client requests A and B were made. Did request A finish? Did request B finish?" In the current master, it's impossible to tell if the put completion notification was for request A or request B. This PR makes an attempt at fixing that.