### PR TITLE
REF: rework CA cache for get requests (improved thread safety and such)

### DIFF
--- a/epics/ca.py
+++ b/epics/ca.py
@@ -1008,7 +1008,7 @@ def connect_channel(chid, timeout=None, verbose=False):
 def replace_access_rights_event(chid, callback=None):
     ch = get_cache(name(chid))
 
-    if callback is not None:
+    if ch and callback is not None:
         ch.access_event_callback.append(callback)
 
     ret = libca.ca_replace_access_rights_event(chid, _CB_ACCESS)
@@ -1291,6 +1291,9 @@ def get_with_metadata(chid, ftype=None, count=None, wait=True, timeout=None,
         count = min(count, element_count(chid))
 
     entry = get_cache(name(chid))
+    if not entry:
+        return
+
     # implementation note: cached value of
     #   None        implies no value, no expected callback
     #   GET_PENDING implies no value yet, callback expected.
@@ -1419,6 +1422,9 @@ def get_complete_with_metadata(chid, ftype=None, count=None, timeout=None,
         count = min(count, element_count(chid))
 
     entry = get_cache(name(chid))
+    if not entry:
+        return
+
     get_result = entry.get_results[ftype]
 
     if get_result[0] is None:

--- a/epics/ca.py
+++ b/epics/ca.py
@@ -27,7 +27,7 @@ import warnings
 from math import log10
 from pkg_resources import resource_filename
 
-from .utils import (STR2BYTES, BYTES2STR, NULLCHAR, NULLCHAR_2,
+from .utils import (STR2BYTES, BYTES2STR, NULLCHAR_2,
                     strjoin, memcopy, is_string, is_string_or_bytes,
                     ascii_string, clib_search_path)
 
@@ -78,7 +78,6 @@ DEFAULT_CONNECTION_TIMEOUT = 2.0
 ## Cache of existing channel IDs:
 # Keyed on context, then on pv name (e.g., _cache[ctx][pvname])
 _cache = collections.defaultdict(dict)
-_namecache = {}
 
 # Puts with completion in progress:
 _put_completes = []
@@ -958,7 +957,6 @@ def create_channel(pvname, connect=False, auto_cb=True, callback=None):
                                           ctypes.byref(chid))
             PySEVCHK('create_channel', ret)
 
-    _namecache[_chid_to_int(chid)] = BYTES2STR(pvn)
     if connect:
         connect_channel(chid)
     return chid
@@ -1053,16 +1051,7 @@ def _chid_to_int(chid):
 @withCHID
 def name(chid):
     "return PV name for channel name"
-    # sys.stdout.write("NAME %s %s\n" % (repr(chid), repr(chid.value in _namecache)))
-    # sys.stdout.flush()
-
-    chid = _chid_to_int(chid)
-    try:
-        return _namecache[chid]
-    except KeyError:
-        name = BYTES2STR(libca.ca_name(chid))
-        _namecache[chid] = name
-        return name
+    return BYTES2STR(libca.ca_name(chid))
 
 @withCHID
 def host_name(chid):

--- a/epics/ca.py
+++ b/epics/ca.py
@@ -86,11 +86,8 @@ _put_completes = []
 
 class _GetPending:
     """
-    _GetPending is used to create a unique python value that cannot be held as
-    an actual PV value.
-
-    A unique python value that cannot be a value held by an actual PV to signal
-    "Get is incomplete, awaiting callback"
+    A unique python object that cannot be a value held by an actual PV to
+    signal "Get is incomplete, awaiting callback"
     """
     def __repr__(self):
         return 'GET_PENDING'
@@ -150,10 +147,8 @@ class _CacheItem:
         Number of failed connection attempts
     get_results : dict
         Keyed on the requested field type -> requested value
-        This is cleared when no further requesters exist.
     callbacks : list
-        One or more user functions to be called on change (accumulated in the
-        cache)
+        One or more user functions to be called on change of value
     access_event_callbacks : list
         One or more user functions to be called on change of access rights
     '''

--- a/epics/ca.py
+++ b/epics/ca.py
@@ -85,13 +85,21 @@ _namecache = {}
 ## Cache of pvs waiting for put to be done.
 _put_done =  {}
 
-# get a unique python value that cannot be a value held by an
-# actual PV to signal "Get is incomplete, awaiting callback"
-class Empty:
-    """used to create a unique python value that cannot be
-    held as an actual PV value"""
-    pass
-GET_PENDING = Empty()
+class _GetPending:
+    """
+    _GetPending is used to create a unique python value that cannot be held as
+    an actual PV value.
+
+    A unique python value that cannot be a value held by an actual PV to signal
+    "Get is incomplete, awaiting callback"
+    """
+    def __repr__(self):
+        return 'GET_PENDING'
+
+
+Empty = _GetPending  # back-compat
+GET_PENDING = _GetPending()
+
 
 class ChannelAccessException(Exception):
     """Channel Access Exception: General Errors"""

--- a/epics/ca.py
+++ b/epics/ca.py
@@ -205,7 +205,7 @@ class _CacheItem:
             The event timestamp
         '''
         self.conn = conn
-        self.timestamp = timestamp
+        self.ts = timestamp
         self.failures = 0
 
         chid_int = self.chid_int

--- a/epics/ca.py
+++ b/epics/ca.py
@@ -719,8 +719,6 @@ def _onAccessRightsEvent(args):
     ra = bool(args.read_access)
     wa = bool(args.write_access)
 
-    # Getting bunk result from ca.current_context on channel disconnect
-    # Do this the long way...
     entry = get_cache(pvname)
     if entry is not None:
         entry.run_access_event_callbacks(ra, wa)

--- a/epics/ca.py
+++ b/epics/ca.py
@@ -1145,7 +1145,7 @@ def promote_fieldtype(ftype, use_time=False, use_ctrl=False):
 
 def _unpack(chid, data, count=None, ftype=None, as_numpy=True):
     """unpacks raw data for a Channel ID `chid` returned by libca functions
-    including `ca_get_array_callback` or subscription callback, and returns
+    including `ca_array_get_callback` or subscription callback, and returns
     the corresponding Python data
 
     Normally, users are not expected to need to access this function, but

--- a/epics/ca.py
+++ b/epics/ca.py
@@ -710,24 +710,6 @@ def _onAccessRightsEvent(args):
         bool(args.read_access), bool(args.write_access))
 
 
-if dbr.PY64_WINDOWS:
-    def _py64_wrapper(func):
-        @functools.wraps(func)
-        def wrapped(arg, **kwargs):
-            # On 64-bit Windows, `arg.contents` seems to be equivalent to other
-            # platforms' `arg`
-            if hasattr(arg, 'contents'):
-                return func(arg.contents, **kwargs)
-            return func(arg, **kwargs)
-        return wrapped
-
-    _onConnectionEvent = _py64_wrapper(_onConnectionEvent)
-    _onPutEvent = _py64_wrapper(_onPutEvent)
-    _onGetEvent = _py64_wrapper(_onGetEvent)
-    _onMonitorEvent = _py64_wrapper(_onMonitorEvent)
-    _onAccessRightsEvent = _py64_wrapper(_onAccessRightsEvent)
-
-
 # create global reference to these callbacks
 _CB_CONNECT = dbr.make_callback(_onConnectionEvent, dbr.connection_args)
 _CB_PUTWAIT = dbr.make_callback(_onPutEvent,        dbr.event_handler_args)

--- a/epics/ca.py
+++ b/epics/ca.py
@@ -141,10 +141,6 @@ class _CacheItem:
         The connection timestamp (or last failed attempt)
     failures : int
         Number of failed connection attempts
-    requester_count : dict
-        The number of active requests (i.e., those that have yet to call
-        get_complete) associated with a single get request.
-        Keyed on the requested field type -> integer count
     get_results : dict
         Keyed on the requested field type -> requested value
         This is cleared when no further requesters exist.
@@ -163,8 +159,7 @@ class _CacheItem:
         self.ts = ts
         self.failures = 0
 
-        self.requester_count = collections.defaultdict(lambda: 0)
-        self.get_results = collections.defaultdict(lambda: None)
+        self.get_results = collections.defaultdict(lambda: [None])
 
         if callbacks is None:
             callbacks = []
@@ -663,7 +658,7 @@ def _onGetEvent(args, **kws):
         result = memcopy(dbr.cast_args(args))
 
     with entry.lock:
-        entry.get_results[ftype] = result
+        entry.get_results[ftype][0] = result
 
 
 ## put event handler:
@@ -1309,10 +1304,8 @@ def get_with_metadata(chid, ftype=None, count=None, wait=True, timeout=None,
     #   None        implies no value, no expected callback
     #   GET_PENDING implies no value yet, callback expected.
     with entry.lock:
-        entry.requester_count[ftype] += 1
-        request_pending = entry.get_results[ftype] is GET_PENDING
-        if not request_pending:
-            entry.get_results[ftype] = GET_PENDING
+        if entry.get_results[ftype][0] is not GET_PENDING:
+            entry.get_results[ftype] = [GET_PENDING]
             ret = libca.ca_array_get_callback(
                 ftype, count, chid, _CB_GET, ctypes.py_object(ftype))
             PySEVCHK('get', ret)
@@ -1434,7 +1427,9 @@ def get_complete_with_metadata(chid, ftype=None, count=None, timeout=None,
         count = min(count, element_count(chid))
 
     entry = get_cache(name(chid))
-    if entry.get_results[ftype] is None:
+    get_result = entry.get_results[ftype]
+
+    if get_result[0] is None:
         warnings.warn('get_complete without initial get() call')
         return None
 
@@ -1442,22 +1437,17 @@ def get_complete_with_metadata(chid, ftype=None, count=None, timeout=None,
     if timeout is None:
         timeout = 1.0 + log10(max(1, count))
 
-    while True:
+    while get_result[0] is GET_PENDING:
         poll()
-        full_value = entry.get_results[ftype]
-        if full_value is not GET_PENDING:
-            break
 
         if time.time()-t0 > timeout:
             msg = "ca.get('%s') timed out after %.2f seconds."
             warnings.warn(msg % (name(chid), timeout))
             return None
 
+    full_value, = get_result
+
     # print("Get Complete> Unpack ", ncache['value'], count, ftype)
-    with entry.lock:
-        entry.requester_count[ftype] -= 1
-        if entry.requester_count[ftype] == 0:
-            entry.get_results[ftype] = None
 
     if isinstance(full_value, Exception):
         get_failure_reason = full_value

--- a/epics/ca.py
+++ b/epics/ca.py
@@ -688,7 +688,9 @@ def _onGetEvent(args, **kws):
     else:
         result = memcopy(dbr.cast_args(args))
 
-    entry.get_results[ftype] = result
+    with entry.lock:
+        entry.get_results[ftype] = result
+
 
 ## put event handler:
 def _onPutEvent(args, **kwds):

--- a/epics/dbr.py
+++ b/epics/dbr.py
@@ -10,6 +10,7 @@
 This is mostly copied from CA header files
 """
 import ctypes
+import functools
 import os
 import sys
 import platform
@@ -317,12 +318,25 @@ def cast_args(args):
                 ctypes.cast(args.raw_dbr,
                             ctypes.POINTER(args.count * Map[ftype])).contents
                 ]
-def make_callback(func, args):
-    """ make callback function"""
-    # note that ctypes.POINTER is needed for 64-bit Python on Windows
-    if PY64_WINDOWS:
-        args = ctypes.POINTER(args)
-    return ctypes.CFUNCTYPE(None, args)(func)
+
+
+if PY64_WINDOWS:
+    def make_callback(func, args):
+        """ make callback function"""
+        # note that ctypes.POINTER is needed for 64-bit Python on Windows
+        @functools.wraps(func)
+        def wrapped(arg, **kwargs):
+            # On 64-bit Windows, `arg.contents` seems to be equivalent to other
+            # platforms' `arg`
+            if hasattr(arg, 'contents'):
+                return func(arg.contents, **kwargs)
+            return func(arg, **kwargs)
+
+        return ctypes.CFUNCTYPE(None, ctypes.POINTER(args))(wrapped)
+else:
+    def make_callback(func, args):
+        """ make callback function"""
+        return ctypes.CFUNCTYPE(None, args)(func)
 
 
 class event_handler_args(ctypes.Structure):

--- a/epics/pv.py
+++ b/epics/pv.py
@@ -318,6 +318,9 @@ class PV(object):
         0
         >>> get_pv('13BMD:m1.DIR').get(as_string=True)
         'Pos'
+
+        If the Channel Access status code sent by the IOC indicates a failure,
+        this method will raise the exception ChannelAccessGetFailure.
         """
         data = self.get_with_metadata(count=count, as_string=as_string,
                                       as_numpy=as_numpy, timeout=timeout,

--- a/epics/pv.py
+++ b/epics/pv.py
@@ -394,12 +394,12 @@ class PV(object):
             if count is None and self._args['count']!=self._args['nelm']:
                 count = self._args['count']
 
-            ca_get = ca.get_with_metadata
-            if ca.get_cache(self.pvname)['value'] is not None:
-                ca_get = ca.get_complete_with_metadata
-
-            md = ca_get(self.chid, ftype=ftype, count=count,
-                        timeout=timeout, as_numpy=as_numpy)
+            # ca.get_with_metadata will handle multiple requests for the same
+            # PV internally, so there is no need to change between
+            # `get_with_metadata` and `get_complete_with_metadata` here.
+            md = ca.get_with_metadata(
+                self.chid, ftype=ftype, count=count, timeout=timeout,
+                as_numpy=as_numpy)
             if md is None:
                 # Get failed. Indicate with a `None` as the return value
                 return

--- a/tests/test_threading.py
+++ b/tests/test_threading.py
@@ -1,5 +1,3 @@
-import pytest
-
 import epics
 import threading
 import pvnames

--- a/tests/test_threading.py
+++ b/tests/test_threading.py
@@ -71,33 +71,3 @@ def test_pv_from_main():
     t.join()
 
     assert len(result) and result[0] is not None
-
-
-@pytest.mark.parametrize('num_threads', [1, 200])
-def test_pv_multithreaded_get(num_threads):
-    def thread(thread_idx):
-        result[thread_idx] = (pv.get(),
-                              pv.get_with_metadata(form='ctrl')['value'],
-                              pv.get_with_metadata(form='time')['value'],
-                              )
-
-    result = {}
-    epics.ca.use_initial_context()
-    pv = epics.PV(pvnames.double_pv2)
-
-    threads = [epics.ca.CAThread(target=thread,
-                                 args=(i, ))
-               for i in range(num_threads)]
-
-    for thread in threads:
-        thread.start()
-    for thread in threads:
-        thread.join()
-
-    assert len(result) == num_threads
-    print(result)
-    values = set(result.values())
-    assert len(values) == 1
-
-    value, = values
-    assert value is not None

--- a/tests/test_threading.py
+++ b/tests/test_threading.py
@@ -73,7 +73,7 @@ def test_pv_from_main():
     assert len(result) and result[0] is not None
 
 
-@pytest.mark.parametrize('num_threads', [1, 100])
+@pytest.mark.parametrize('num_threads', [1, 200])
 def test_pv_multithreaded_get(num_threads):
     def thread(thread_idx):
         result[thread_idx] = (pv.get(),


### PR DESCRIPTION
This is the largest change from #147 that couldn't be easily separated. It's also the part that deserves the most scrutiny prior to (potential) merging.

Issues
-------
1. Multiple threads attempting to read the same PV quickly fail due to a race condition with the built-in `epics.ca._cache`
2. `ca.get()` which returns anything but `ECA_NORMAL` will show up in pyepics as `TimeoutError`
3. `get_timevars`, `get_ctrlvars` duplicate a lot of `get_with_metadata` code unnecessarily.
4. Access rights, connection callbacks were being run for all contexts
    This did not make sense to me, and it is not present in this refactor. If I misunderstood that, we should revisit this. (@dchabot, I believe this was from your PR?)
5. `_namecache` is not keyed on context. This PR removes the namecache entirely.

Fix to issue 1
-------------
Added test `pv_unittest.test_multithreaded_get` shows how to easily trigger this failure.

 In master, this is a race to "who gets the result first", with the rest failing somewhere in `get_complete` (or receiving `None`). With this PR, simultaneous get requests can now share the result.
The logic is now as follows: 
   * If there is an in-process get request for a specific field type (e.g., DBR_CTRL_INT) for a PV, other callers to `get()` with those same parameters will share the result and not duplicate the `libca` call. 
   * `get()` and `get_complete()` are two separate calls in pyepics. That means that in-between a call to `get()` and `get_complete()` on the user-side, it's possible that one or more duplicate get requests may have happened in separate threads. The end result would be that each call to `get_complete()` would get the latest value, and not necessarily the one that was in-flight when `get()` itself was called. I don't see an obvious way around this with the current API, but I don't necessarily think it's much of an issue, either.
  * There is a (mostly) minimal set of locking in place to keep track of these requests. 
  * Now, the codebase is more rigorous about the per-context cache bookkeeping
      * Adds a `_CacheItem` class that handles some of this. It keeps back-compat with `__getitem__` - but really clients should _not_ be touching the cache at all.

Fix to issue 2
------------------------
`ca.get()` can fail and not return _any_ result to the user, ending in a timeout condition. This happens due to the check in `_onGetEvent`: https://github.com/pyepics/pyepics/blob/7fe180e0ab857f8189b4e1b048608235ac45b045/epics/ca.py#L613

This is resolved in this PR with the exception status propagating back to the user. This is a slight API break - errors that used to be masked as timeouts will now raise `ChannelAccessGetFailure`.

Fix to issue 3
--------------
* Refactors `get_timevars`, `get_ctrlvars` using `get_with_metadata`. All `get_*()`-related functions are now routed through this function only.

Fix to issue 4
-------------
* Only the access rights/connection callbacks for the specific context are run after this PR.

Miscellaneous improvements
-----------------------------
* Tweak `GET_PENDING` to have a nice repr
* Use `defaultdict` to remove a bunch of `if ca.current_context() not in _cache` checks