### PR TITLE
ENH: add _ensure_context decorator, guard against multithreaded access of `epics.PV`

### DIFF
--- a/epics/pv.py
+++ b/epics/pv.py
@@ -195,6 +195,7 @@ class PV(object):
         if pvid not in _PVcache_:
             _PVcache_[pvid] = self
 
+    @_ensure_context
     def force_connect(self, pvname=None, chid=None, conn=True, **kws):
         if chid is None: chid = self.chid
         if isinstance(chid, ctypes.c_long):
@@ -213,6 +214,7 @@ class PV(object):
         self._args['read_access'] = (1 == ca.read_access(self.chid))
         self._args['write_access'] = (1 == ca.write_access(self.chid))
 
+    @_ensure_context
     def __on_access_rights_event(self, read_access, write_access):
         self._args['read_access'] = read_access
         self._args['write_access'] = write_access
@@ -225,6 +227,7 @@ class PV(object):
             if callable(cb):
                 cb(read_access, write_access, pv=self)
 
+    @_ensure_context
     def __on_connect(self, pvname=None, chid=None, conn=True):
         "callback for connection events"
         # occassionally chid is still None (ie if a second PV is created
@@ -649,6 +652,7 @@ class PV(object):
                                      self._args['char_value'], now))
         self.run_callbacks()
 
+    @_ensure_context
     def run_callbacks(self):
         """run all user-defined callbacks with the current data
 
@@ -659,6 +663,7 @@ class PV(object):
         for index in sorted(list(self.callbacks.keys())):
             self.run_callback(index)
 
+    @_ensure_context
     def run_callback(self, index):
         """run a specific user-defined callback, specified by index,
         with the current data
@@ -705,6 +710,7 @@ class PV(object):
                 self.run_callback(index)
         return index
 
+    @_ensure_context
     def remove_callback(self, index=None):
         """remove a callback by index"""
         if index in self.callbacks:

--- a/epics/pv.py
+++ b/epics/pv.py
@@ -299,8 +299,6 @@ class PV(object):
     @_ensure_context
     def wait_for_connection(self, timeout=None):
         """wait for a connection that started with connect() to finish"""
-
-        # make sure we're in the CA context used to create this PV
         if not self.connected:
             start_time = time.time()
             if not self._conn_started:

--- a/tests/pv_unittest.py
+++ b/tests/pv_unittest.py
@@ -5,6 +5,7 @@ import sys
 import time
 import unittest
 import numpy
+import threading
 import pytest
 
 from contextlib import contextmanager
@@ -520,7 +521,8 @@ class PV_Tests(unittest.TestCase):
 
 
 @pytest.mark.parametrize('num_threads', [1, 10, 200])
-def test_multithreaded_get(num_threads):
+@pytest.mark.parametrize('thread_class', [ca.CAThread, threading.Thread])
+def test_multithreaded_get(num_threads, thread_class):
     def thread(thread_idx):
         result[thread_idx] = (pv.get(),
                               pv.get_with_metadata(form='ctrl')['value'],
@@ -531,7 +533,7 @@ def test_multithreaded_get(num_threads):
     ca.use_initial_context()
     pv = PV(pvnames.double_pv)
 
-    threads = [ca.CAThread(target=thread, args=(i, ))
+    threads = [thread_class(target=thread, args=(i, ))
                for i in range(num_threads)]
 
     with no_simulator_updates():


### PR DESCRIPTION
Allows any thread, using any CA context, to access an `epics.PV` object safely.

The modified test verifies the functionality alongside `epics.CAThread`, which is largely made unnecessary with this change.

A much simpler example of which this PR aims to fix, which will fail on master (click for details):

<details>

```python
import threading
import epics


def test(i):
    print()
    print('---- test {} ----'.format(i))
    epics.ca.create_context()
    print('created context', epics.ca.current_context())

    print(pv.get())
    print(pv.nelm)
    print(epics.ca._cache)


pv = epics.PV('Py:ao1', auto_monitor=False)
pv.wait_for_connection()

for i in range(5):
    thread = threading.Thread(target=test, args=(i, ))
    thread.start()
    thread.join()
```

With the current master, we see:
```sh
$ python threaded_access.py
---- test 0 ----
created context 140197677284720
None
1
defaultdict(<class 'dict'>, {140197715687376: {'Py:ao1': <epics.ca._CacheItem object at 0x105987860>}, 140197677284720: {}})

---- test 1 ----
created context 140197679474720
None
1
defaultdict(<class 'dict'>, {140197715687376: {'Py:ao1': <epics.ca._CacheItem object at 0x105987860>}, 140197677284720: {}, 140197679474720: {}})

---- test 2 ----
created context 140197677388512
None
1
defaultdict(<class 'dict'>, {140197715687376: {'Py:ao1': <epics.ca._CacheItem object at 0x105987860>}, 140197677284720: {}, 140197679474720: {}, 140197677388512: {}})

---- test 3 ----
created context 140197679546976
None
1
defaultdict(<class 'dict'>, {140197715687376: {'Py:ao1': <epics.ca._CacheItem object at 0x105987860>}, 140197677284720: {}, 140197679474720: {}, 140197677388512: {}, 140197679546976: {}})

---- test 4 ----
created context 140197677426480
None
1
defaultdict(<class 'dict'>, {140197715687376: {'Py:ao1': <epics.ca._CacheItem object at 0x105987860>}, 140197677284720: {}, 140197679474720: {}, 140197677388512: {}, 140197679546976: {}, 140197677426480: {}})
```

With this PR, we see:

```sh
$ python threaded_access.py

---- test 0 ----
created context 140232599604656
5.33379434247252
1
defaultdict(<class 'dict'>, {140232600730528: {'Py:ao1': <epics.ca._CacheItem object at 0x10860db70>}})

---- test 1 ----
created context 140232600755584
5.33379434247252
1
defaultdict(<class 'dict'>, {140232600730528: {'Py:ao1': <epics.ca._CacheItem object at 0x10860db70>}})

---- test 2 ----
created context 140232638468048
5.33379434247252
1
defaultdict(<class 'dict'>, {140232600730528: {'Py:ao1': <epics.ca._CacheItem object at 0x10860db70>}})

---- test 3 ----
created context 140232601293600
5.33379434247252
1
defaultdict(<class 'dict'>, {140232600730528: {'Py:ao1': <epics.ca._CacheItem object at 0x10860db70>}})

---- test 4 ----
created context 140232601329568
5.33379434247252
1
defaultdict(<class 'dict'>, {140232600730528: {'Py:ao1': <epics.ca._CacheItem object at 0x10860db70>}})
```
</details>

I believe this will alleviate most of the threading issues people run into using `epics.PV`. 

If we agree this is a good thing, someone should at least double check that I didn't forget to wrap any other important methods on `epics.PV` with `_ensure_context`.