### PR TITLE
FIX: timeout during get_timevars

### DIFF
--- a/epics/ca.py
+++ b/epics/ca.py
@@ -1686,8 +1686,9 @@ def get_ctrlvars(chid, timeout=5.0, warn=True):
     ftype = promote_type(chid, use_ctrl=True)
     metadata = get_with_metadata(chid, ftype=ftype, count=1, timeout=timeout,
                                  wait=True)
-    # Ignore the value returned:
-    metadata.pop('value', None)
+    if metadata is not None:
+        # Ignore the value returned:
+        metadata.pop('value', None)
     return metadata
 
 
@@ -1699,8 +1700,9 @@ def get_timevars(chid, timeout=5.0, warn=True):
     ftype = promote_type(chid, use_time=True)
     metadata = get_with_metadata(chid, ftype=ftype, count=1, timeout=timeout,
                                  wait=True)
-    # Ignore the value returned:
-    metadata.pop('value', None)
+    if metadata is not None:
+        # Ignore the value returned:
+        metadata.pop('value', None)
     return metadata
 
 

--- a/epics/pv.py
+++ b/epics/pv.py
@@ -571,7 +571,8 @@ class PV(object):
         if not self.wait_for_connection():
             return None
         kwds = ca.get_ctrlvars(self.chid, timeout=timeout, warn=warn)
-        self._args.update(kwds)
+        if kwds is not None:
+            self._args.update(kwds)
         self.force_read_access_rights()
         return kwds
 
@@ -580,7 +581,8 @@ class PV(object):
         if not self.wait_for_connection():
             return None
         kwds = ca.get_timevars(self.chid, timeout=timeout, warn=warn)
-        self._args.update(kwds)
+        if kwds is not None:
+            self._args.update(kwds)
         return kwds
 
 

--- a/tests/pv_unittest.py
+++ b/tests/pv_unittest.py
@@ -578,6 +578,36 @@ def test_multithreaded_put_complete(num_threads):
     assert set(result) == set(range(num_threads))
 
 
+def test_force_connect():
+    pv = PV(pvnames.double_arrays[0], auto_monitor=True)
+
+    print("Connecting")
+    assert pv.wait_for_connection(5.0)
+
+    print("SUM", pv.get().sum())
+
+    time.sleep(3)
+
+    print("Disconnecting")
+    pv.disconnect()
+    print("Reconnecting")
+
+    pv.force_connect()
+    assert pv.wait_for_connection(5.0)
+
+    called = {'called': False}
+
+    def callback(value=None, **kwargs):
+        called['called'] = True
+        print("update", value.sum())
+
+    pv.add_callback(callback)
+
+    time.sleep(1)
+    assert pv.get() is not None
+    assert called['called']
+
+
 if __name__ == '__main__':
     suite = unittest.TestLoader().loadTestsFromTestCase( PV_Tests)
     unittest.TextTestRunner(verbosity=1).run(suite)


### PR DESCRIPTION
In the case of timeout, these functions return `None`. Comparing against `None` is necessary prior to attempting to update internal PV state dictionaries.

Also adds a test based on #68. It *appears* to no longer be an issue, but I'm not 100% certain as of yet. More tests should be done.