### PR TITLE
FIX: auto monitor on reconnect

### DIFF
--- a/epics/pv.py
+++ b/epics/pv.py
@@ -323,6 +323,7 @@ class PV(object):
     @_ensure_context
     def clear_auto_monitor(self):
         """turn off auto-monitoring: must reconnect to re-enable monitoring"""
+        self.auto_monitor = False
         if self._monref is not None:
             evid = self._monref[2]
             ca.clear_subscription(evid)

--- a/epics/pv.py
+++ b/epics/pv.py
@@ -233,7 +233,6 @@ class PV(object):
         # occassionally chid is still None (ie if a second PV is created
         # while __on_connect is still pending for the first one.)
         # Just return here, and connection will happen later
-        t0 = time.time()
         if self.chid is None and chid is None:
             ca.poll(5.e-4)
             return

--- a/epics/pv.py
+++ b/epics/pv.py
@@ -324,7 +324,6 @@ class PV(object):
     @_ensure_context
     def clear_auto_monitor(self):
         """turn off auto-monitoring: must reconnect to re-enable monitoring"""
-        self.auto_monitor = False
         if self._monref is not None:
             evid = self._monref[2]
             ca.clear_subscription(evid)
@@ -332,7 +331,6 @@ class PV(object):
 
     def reconnect(self):
         "try to reconnect PV"
-        self.auto_monitor = None
         self._monref = None
         self.connected = False
         self._conn_started = False


### PR DESCRIPTION
With this PR, both `PV.clear_auto_monitor` and `PV.reconnect` will not reset the boolean `auto_monitor` - which determines whether or not to set up a monitor automatically on PV connection. 

This means that the one-time logic that set `auto_monitor` upon the initial connection will be re-used for subsequent reconnections (except if the user modifies the attribute directly).

Closes #145