### PR TITLE
FIX: clear channel should remove cache item

### DIFF
--- a/epics/ca.py
+++ b/epics/ca.py
@@ -169,6 +169,18 @@ class _CacheItem:
         self.callbacks = callbacks
         self.access_event_callback = []
 
+    def __repr__(self):
+        return (
+            '<{} {!r} {} failures={} callbacks={} access_callbacks={}>'
+            ''.format(self.__class__.__name__,
+                      repr(self.pvname),
+                      'connected' if self.conn else 'disconnected',
+                      self.failures,
+                      len(self.callbacks),
+                      len(self.access_event_callback)
+                      )
+        )
+
     def __getitem__(self, key):
         # back-compat
         return getattr(self, key)

--- a/epics/ca.py
+++ b/epics/ca.py
@@ -573,9 +573,7 @@ def withCHID(fcn):
                 msg = "%s: not a valid chid %s %s args %s kwargs %s!" % (
                     (fcn.__name__, chid, type(chid), args, kwds))
                 raise ChannelAccessException(msg)
-            cache = _cache[current_context()]
             if chid.value not in _chid_cache:
-                print('unexpected chid', chid.value, chid, cache)
                 raise ChannelAccessException('Unexpected channel ID')
         return fcn(*args, **kwds)
     return wrapper

--- a/epics/ca.py
+++ b/epics/ca.py
@@ -1119,10 +1119,15 @@ def field_type(chid):
 @withCHID
 def clear_channel(chid):
     "clear the channel"
+    ret = libca.ca_clear_channel(chid)
+    entry = _chid_cache.pop(chid.value, None)
     context_cache = _cache[current_context()]
     context_cache.pop(name(chid), None)
-    _chid_cache.pop(chid.value, None)
-    return libca.ca_clear_channel(chid)
+    if entry is not None:
+        with entry.lock:
+            entry.chid = None
+    return ret
+
 
 @withCHID
 def state(chid):

--- a/epics/ca.py
+++ b/epics/ca.py
@@ -417,7 +417,6 @@ def finalize_libca(maxtime=10.0):
         poll()
         for chid, entry in list(_chid_cache.items()):
             try:
-                print('clearing chid', chid, name(chid))
                 clear_channel(chid)
             except ChannelAccessException:
                 pass
@@ -434,7 +433,6 @@ def finalize_libca(maxtime=10.0):
         context_destroy()
         libca = None
     except:
-        print('catch-all for exceptions', sys.exc_info())
         pass
     time.sleep(0.01)
 

--- a/epics/ca.py
+++ b/epics/ca.py
@@ -440,8 +440,22 @@ def finalize_libca(maxtime=10.0):
 
 
 def get_cache(pvname):
-    "return cache dictionary for a given pvname in the current context"
+    "return _CacheItem for a given pvname in the current context"
     return _cache[current_context()].get(pvname, None)
+
+
+def _get_cache_by_chid(chid):
+    'return _CacheItem for a given channel id'
+    try:
+        return _chid_cache[chid]
+    except KeyError:
+        # It's possible that the channel id cache is not yet ready; check the
+        # context cache before giving up. This branch should not happen often.
+        context = current_context()
+        if context is not None:
+            pvname = BYTES2STR(libca.ca_name(dbr.chid_t(chid)))
+            return _cache[context][pvname]
+        raise
 
 
 def show_cache(print_out=True):

--- a/epics/ca.py
+++ b/epics/ca.py
@@ -178,7 +178,7 @@ class _CacheItem:
 
     @chid.setter
     def chid(self, chid):
-        if not isinstance(chid, dbr.chid_t):
+        if chid is not None and not isinstance(chid, dbr.chid_t):
             chid = dbr.chid_t(chid)
 
         self._chid = chid

--- a/epics/ca.py
+++ b/epics/ca.py
@@ -401,7 +401,7 @@ def finalize_libca(maxtime=10.0):
         for ctxid, ctx in _cache.items():
             for pvname, info in ctx.items():
                 if info.chid is not None:
-                    clear_channel(info.chid)
+                    libca.ca_clear_channel(chid)
             ctx.clear()
         _cache.clear()
         flush_count = 0
@@ -1074,6 +1074,7 @@ def field_type(chid):
 @withCHID
 def clear_channel(chid):
     "clear the channel"
+    _cache[current_context()].pop(name(chid), None)
     return libca.ca_clear_channel(chid)
 
 @withCHID

--- a/epics/ca.py
+++ b/epics/ca.py
@@ -484,9 +484,6 @@ def show_cache(print_out=True):
     out.append('#--------------------------------------------')
     for context, context_chids in  list(_cache.items()):
         for vname, val in list(context_chids.items()):
-            if isinstance(vname, int):
-                continue
-
             chid = val.chid
             if len(vname) < 15:
                 vname = (vname + ' '*15)[:15]

--- a/epics/ca.py
+++ b/epics/ca.py
@@ -220,7 +220,7 @@ class _CacheItem:
             if callable(callback):
                 callback(ra, wa)
 
-    def run_connection_callbacks(self, chid, conn, timestamp):
+    def run_connection_callbacks(self, conn, timestamp):
         '''
         Run all connection callbacks
 
@@ -700,8 +700,7 @@ def _onConnectionEvent(args):
         # cache item
         return
 
-    entry.run_connection_callbacks(dbr.chid_t(args.chid),
-                                   conn=(args.op == dbr.OP_CONN_UP),
+    entry.run_connection_callbacks(conn=(args.op == dbr.OP_CONN_UP),
                                    timestamp=time.time())
 
 

--- a/epics/ca.py
+++ b/epics/ca.py
@@ -138,6 +138,8 @@ class _CacheItem:
         A lock for modifying the state
     conn : bool
         The connection status
+    context : int
+        The context in which this is CacheItem was created in
     chid : ctypes.c_long
         The channel ID
     pvname : str

--- a/epics/ca.py
+++ b/epics/ca.py
@@ -1075,10 +1075,11 @@ def field_type(chid):
 @withCHID
 def clear_channel(chid):
     "clear the channel"
+    pvname = name(chid)
     ret = libca.ca_clear_channel(chid)
     entry = _chid_cache.pop(chid.value, None)
     context_cache = _cache[current_context()]
-    context_cache.pop(name(chid), None)
+    context_cache.pop(pvname, None)
     if entry is not None:
         with entry.lock:
             entry.chid = None

--- a/epics/ca.py
+++ b/epics/ca.py
@@ -187,7 +187,7 @@ class _CacheItem:
         return (
             '<{} {!r} {} failures={} callbacks={} access_callbacks={} chid={}>'
             ''.format(self.__class__.__name__,
-                      repr(self.pvname),
+                      self.pvname,
                       'connected' if self.conn else 'disconnected',
                       self.failures,
                       len(self.callbacks),

--- a/epics/ca.py
+++ b/epics/ca.py
@@ -671,9 +671,8 @@ def _onConnectionEvent(args):
     except KeyError:
         return
 
-    if entry is not None:
-        entry.run_connection_callbacks(conn=(args.op == dbr.OP_CONN_UP),
-                                       timestamp=time.time())
+    entry.run_connection_callbacks(conn=(args.op == dbr.OP_CONN_UP),
+                                   timestamp=time.time())
 
 
 ## get event handler:

--- a/epics/ca.py
+++ b/epics/ca.py
@@ -649,7 +649,7 @@ def withSEVCHK(fcn):
 def _onMonitorEvent(args):
     """Event Handler for monitor events: not intended for use"""
     try:
-        _chid_cache[_chid_to_int(args.chid)]
+        entry = _get_cache_by_chid(args.chid)
     except KeyError:
         # In case the chid is no longer in our cache, exit now.
         return
@@ -663,9 +663,8 @@ def _onMonitorEvent(args):
         return
 
     value = dbr.cast_args(args)
-    pvname = name(args.chid)
     kwds = {'ftype':args.type, 'count':args.count,
-            'chid':args.chid, 'pvname': pvname}
+            'chid': args.chid, 'pvname': entry.pvname}
 
     # add kwds arguments for CTRL and TIME variants
     # this is in a try/except clause to avoid problems
@@ -683,7 +682,7 @@ def _onMonitorEvent(args):
 def _onConnectionEvent(args):
     "Connection notification - run user callbacks"
     try:
-        entry = _chid_cache[_chid_to_int(args.chid)]
+        entry = _get_cache_by_chid(args.chid)
     except KeyError:
         return
 
@@ -699,7 +698,7 @@ def _onGetEvent(args, **kws):
     # print("GET EVENT: type, count ", args.type, args.count)
     # print("GET EVENT: status ",  args.status, dbr.ECA_NORMAL)
     try:
-        entry = _chid_cache[_chid_to_int(args.chid)]
+        entry = _get_cache_by_chid(args.chid)
     except KeyError:
         return
 

--- a/epics/ca.py
+++ b/epics/ca.py
@@ -401,7 +401,7 @@ def finalize_libca(maxtime=10.0):
         for ctxid, ctx in _cache.items():
             for pvname, info in ctx.items():
                 if info.chid is not None:
-                    libca.ca_clear_channel(chid)
+                    libca.ca_clear_channel(info.chid)
             ctx.clear()
         _cache.clear()
         flush_count = 0

--- a/epics/ca.py
+++ b/epics/ca.py
@@ -1085,12 +1085,11 @@ def field_type(chid):
 @withCHID
 def clear_channel(chid):
     "clear the channel"
-    pvname = name(chid)
     ret = libca.ca_clear_channel(chid)
     entry = _chid_cache.pop(chid.value, None)
-    context_cache = _cache[current_context()]
-    context_cache.pop(pvname, None)
     if entry is not None:
+        context_cache = _cache[entry.context]
+        context_cache.pop(entry.pvname, None)
         with entry.lock:
             entry.chid = None
     return ret

--- a/epics/pv.py
+++ b/epics/pv.py
@@ -260,7 +260,7 @@ class PV(object):
     @_ensure_context
     def force_connect(self, pvname=None, chid=None, conn=True, **kws):
         if chid is None: chid = self.chid
-        if isinstance(chid, ctypes.c_long):
+        if hasattr(chid, 'value'):
             chid = chid.value
         self._args['chid'] = self.chid = chid
         self.__on_connect(pvname=pvname, chid=chid, conn=conn, **kws)

--- a/tests/pv_unittest.py
+++ b/tests/pv_unittest.py
@@ -9,7 +9,7 @@ import threading
 import pytest
 
 from contextlib import contextmanager
-from epics import get_pv, caput, caget, caget_many, caput_many, ca
+from epics import PV, get_pv, caput, caget, caget_many, caput_many, ca
 
 import pvnames
 
@@ -362,7 +362,9 @@ class PV_Tests(unittest.TestCase):
 
     def test_waveform_get_with_count_arg(self):
         with no_simulator_updates():
-            wf = get_pv(pvnames.char_arr_pv, count=32)
+            # NOTE: do not use get_pv() here, as `count` is incompatible with
+            # the cache
+            wf = PV(pvnames.char_arr_pv, count=32)
             val=wf.get()
             self.assertEquals(len(val), 32)
 
@@ -373,7 +375,9 @@ class PV_Tests(unittest.TestCase):
     def test_waveform_callback_with_count_arg(self):
         values = []
 
-        wf = get_pv(pvnames.char_arr_pv, count=32)
+        # NOTE: do not use get_pv() here, as `count` is incompatible with
+        # the cache
+        wf = PV(pvnames.char_arr_pv, count=32)
         def onChanges(pvname=None, value=None, char_value=None, **kw):
             write( 'PV %s %s, %s Changed!\n' % (pvname, repr(value), char_value))
             values.append( value)

--- a/tests/pv_unittest.py
+++ b/tests/pv_unittest.py
@@ -9,7 +9,7 @@ import threading
 import pytest
 
 from contextlib import contextmanager
-from epics import PV, caput, caget, caget_many, caput_many, ca
+from epics import get_pv, caput, caget, caget_many, caput_many, ca
 
 import pvnames
 
@@ -44,13 +44,12 @@ def no_simulator_updates():
 class PV_Tests(unittest.TestCase):
     def testA_CreatePV(self):
         write('Simple Test: create pv\n')
-        pv = PV(pvnames.double_pv)
+        pv = get_pv(pvnames.double_pv)
         self.assertIsNot(pv, None)
 
     def testA_CreatedWithConn(self):
         write('Simple Test: create pv with conn callback\n')
-        pv = PV(pvnames.int_pv,
-                connection_callback=onConnect)
+        pv = get_pv(pvnames.int_pv, connection_callback=onConnect)
         val = pv.get()
 
         global CONN_DAT
@@ -116,7 +115,7 @@ class PV_Tests(unittest.TestCase):
     def test_get1(self):
         write('Simple Test: test value and char_value on an integer\n')
         with no_simulator_updates():
-            pv = PV(pvnames.int_pv)
+            pv = get_pv(pvnames.int_pv)
             val = pv.get()
             cval = pv.get(as_string=True)
 
@@ -124,7 +123,7 @@ class PV_Tests(unittest.TestCase):
 
     def test_get_with_metadata(self):
         with no_simulator_updates():
-            pv = PV(pvnames.int_pv, form='native')
+            pv = get_pv(pvnames.int_pv, form='native')
 
             # Request time type
             md = pv.get_with_metadata(use_monitor=False, form='time')
@@ -149,7 +148,7 @@ class PV_Tests(unittest.TestCase):
     def test_get_string_waveform(self):
         write('String Array: \n')
         with no_simulator_updates():
-            pv = PV(pvnames.string_arr_pv)
+            pv = get_pv(pvnames.string_arr_pv)
             val = pv.get()
             self.failUnless(len(val) > 10)
             self.assertIsInstance(val[0], str)
@@ -160,7 +159,7 @@ class PV_Tests(unittest.TestCase):
     def test_putcomplete(self):
         write('Put with wait and put_complete (using real motor!) \n')
         vals = (1.35, 1.50, 1.44, 1.445, 1.45, 1.453, 1.446, 1.447, 1.450, 1.450, 1.490, 1.5, 1.500)
-        p = PV(pvnames.motor1)
+        p = get_pv(pvnames.motor1)
         # this works with a real motor, fail if it doesn't connect quickly
         if not p.wait_for_connection(timeout=0.2):
             self.skipTest('Unable to connect to real motor record')
@@ -181,7 +180,7 @@ class PV_Tests(unittest.TestCase):
 
     def test_putwait(self):
         write('Put with wait (using real motor!) \n')
-        pv = PV(pvnames.motor1)
+        pv = get_pv(pvnames.motor1)
         # this works with a real motor, fail if it doesn't connect quickly
         if not pv.wait_for_connection(timeout=0.2):
             self.skipTest('Unable to connect to real motor record')
@@ -239,7 +238,7 @@ class PV_Tests(unittest.TestCase):
     def test_get_callback(self):
         write("Callback test:  changing PV must be updated\n")
         global NEWVALS
-        mypv = PV(pvnames.updating_pv1)
+        mypv = get_pv(pvnames.updating_pv1)
         NEWVALS = []
         def onChanges(pvname=None, value=None, char_value=None, **kw):
             write( 'PV %s %s, %s Changed!\n' % (pvname, repr(value), char_value))
@@ -258,7 +257,7 @@ class PV_Tests(unittest.TestCase):
     def test_put_string_waveform(self):
         write('String Array: put\n')
         with no_simulator_updates():
-            pv = PV(pvnames.string_arr_pv)
+            pv = get_pv(pvnames.string_arr_pv)
             put_value = ['a', 'b', 'c']
             pv.put(put_value, wait=True)
             get_value = pv.get(use_monitor=False, as_numpy=False)
@@ -267,7 +266,7 @@ class PV_Tests(unittest.TestCase):
     def test_put_string_waveform_single_element(self):
         write('String Array: put single element\n')
         with no_simulator_updates():
-            pv = PV(pvnames.string_arr_pv)
+            pv = get_pv(pvnames.string_arr_pv)
             put_value = ['a']
             pv.put(put_value, wait=True)
             time.sleep(0.05)
@@ -277,7 +276,7 @@ class PV_Tests(unittest.TestCase):
     def test_put_string_waveform_mixed_types(self):
         write('String Array: put mixed types\n')
         with no_simulator_updates():
-            pv = PV(pvnames.string_arr_pv)
+            pv = get_pv(pvnames.string_arr_pv)
             put_value = ['a', 2, 'b']
             pv.put(put_value, wait=True)
             time.sleep(0.05)
@@ -287,7 +286,7 @@ class PV_Tests(unittest.TestCase):
     def test_put_string_waveform_empty_list(self):
         write('String Array: put empty list\n')
         with no_simulator_updates():
-            pv = PV(pvnames.string_arr_pv)
+            pv = get_pv(pvnames.string_arr_pv)
             put_value = []
             pv.put(put_value, wait=True)
             time.sleep(0.05)
@@ -297,7 +296,7 @@ class PV_Tests(unittest.TestCase):
     def test_put_string_waveform_zero_length_strings(self):
         write('String Array: put zero length strings\n')
         with no_simulator_updates():
-            pv = PV(pvnames.string_arr_pv)
+            pv = get_pv(pvnames.string_arr_pv)
             put_value = ['', '', '']
             pv.put(put_value, wait=True)
             time.sleep(0.05)
@@ -306,8 +305,8 @@ class PV_Tests(unittest.TestCase):
 
     def test_subarrays(self):
         write("Subarray test:  dynamic length arrays\n")
-        driver = PV(pvnames.subarr_driver)
-        subarr1 = PV(pvnames.subarr1)
+        driver = get_pv(pvnames.subarr_driver)
+        subarr1 = get_pv(pvnames.subarr1)
         subarr1.connect()
 
         len_full = 64
@@ -328,7 +327,7 @@ class PV_Tests(unittest.TestCase):
         caput("%s.NELM" % pvnames.subarr2, 19)
         caput("%s.INDX" % pvnames.subarr2, 3)
 
-        subarr2 = PV(pvnames.subarr2)
+        subarr2 = get_pv(pvnames.subarr2)
         subarr2.get()
 
         driver.put(full_data) ;   time.sleep(0.1)
@@ -347,7 +346,7 @@ class PV_Tests(unittest.TestCase):
         self.failUnless(numpy.all(subval == full_data[13:5+13]))
 
     def test_subarray_zerolen(self):
-        subarr1 = PV(pvnames.zero_len_subarr1)
+        subarr1 = get_pv(pvnames.zero_len_subarr1)
         subarr1.wait_for_connection()
 
         val = subarr1.get(use_monitor=True, as_numpy=True)
@@ -363,7 +362,7 @@ class PV_Tests(unittest.TestCase):
 
     def test_waveform_get_with_count_arg(self):
         with no_simulator_updates():
-            wf = PV(pvnames.char_arr_pv, count=32)
+            wf = get_pv(pvnames.char_arr_pv, count=32)
             val=wf.get()
             self.assertEquals(len(val), 32)
 
@@ -374,7 +373,7 @@ class PV_Tests(unittest.TestCase):
     def test_waveform_callback_with_count_arg(self):
         values = []
 
-        wf = PV(pvnames.char_arr_pv, count=32)
+        wf = get_pv(pvnames.char_arr_pv, count=32)
         def onChanges(pvname=None, value=None, char_value=None, **kw):
             write( 'PV %s %s, %s Changed!\n' % (pvname, repr(value), char_value))
             values.append( value)
@@ -400,7 +399,7 @@ class PV_Tests(unittest.TestCase):
         without using auto_monitor
         '''
         with no_simulator_updates():
-            zerostr = PV(pvnames.char_arr_pv, auto_monitor=False)
+            zerostr = get_pv(pvnames.char_arr_pv, auto_monitor=False)
             zerostr.wait_for_connection()
 
             # elem_count = 128, requested count = None, libca returns count = 1
@@ -422,7 +421,7 @@ class PV_Tests(unittest.TestCase):
         with using auto_monitor
         '''
         with no_simulator_updates():
-            zerostr = PV(pvnames.char_arr_pv, auto_monitor=True)
+            zerostr = get_pv(pvnames.char_arr_pv, auto_monitor=True)
             zerostr.wait_for_connection()
 
             zerostr.put([0], wait=True)
@@ -442,7 +441,7 @@ class PV_Tests(unittest.TestCase):
             numpy.testing.assert_array_equal(zerostr.get(as_string=False, as_numpy=False), [0, 0])
 
     def testEnumPut(self):
-        pv = PV(pvnames.enum_pv)
+        pv = get_pv(pvnames.enum_pv)
         self.assertIsNot(pv, None)
         pv.put('Stop')
         time.sleep(0.1)
@@ -452,7 +451,7 @@ class PV_Tests(unittest.TestCase):
 
     def test_DoubleVal(self):
         pvn = pvnames.double_pv
-        pv = PV(pvn)
+        pv = get_pv(pvn)
         pv.get()
         cdict  = pv.get_ctrlvars()
         write( 'Testing CTRL Values for a Double (%s)\n'   % (pvn))
@@ -498,15 +497,15 @@ class PV_Tests(unittest.TestCase):
                         self.assertEqual(a, b)
 
     def test_waveform_get_1elem(self):
-        pv = PV(pvnames.double_arr_pv)
+        pv = get_pv(pvnames.double_arr_pv)
         val = pv.get(count=1, use_monitor=False)
         self.failUnless(isinstance(val, numpy.ndarray))
         self.failUnless(len(val), 1)
 
     def test_subarray_1elem(self):
         with no_simulator_updates():
-            # pv = PV(pvnames.zero_len_subarr1)
-            pv = PV(pvnames.double_arr_pv)
+            # pv = get_pv(pvnames.zero_len_subarr1)
+            pv = get_pv(pvnames.double_arr_pv)
             pv.wait_for_connection()
 
             val = pv.get(count=1, use_monitor=False)
@@ -531,7 +530,7 @@ def test_multithreaded_get(num_threads, thread_class):
 
     result = {}
     ca.use_initial_context()
-    pv = PV(pvnames.double_pv)
+    pv = get_pv(pvnames.double_pv)
 
     threads = [thread_class(target=thread, args=(i, ))
                for i in range(num_threads)]
@@ -564,7 +563,7 @@ def test_multithreaded_put_complete(num_threads):
 
     result = []
     ca.use_initial_context()
-    pv = PV(pvnames.double_pv)
+    pv = get_pv(pvnames.double_pv)
 
     threads = [ca.CAThread(target=thread, args=(i, ))
                for i in range(num_threads)]
@@ -581,7 +580,7 @@ def test_multithreaded_put_complete(num_threads):
 
 
 def test_force_connect():
-    pv = PV(pvnames.double_arrays[0], auto_monitor=True)
+    pv = get_pv(pvnames.double_arrays[0], auto_monitor=True)
 
     print("Connecting")
     assert pv.wait_for_connection(5.0)

--- a/tests/pv_unittest.py
+++ b/tests/pv_unittest.py
@@ -403,7 +403,7 @@ class PV_Tests(unittest.TestCase):
         without using auto_monitor
         '''
         with no_simulator_updates():
-            zerostr = get_pv(pvnames.char_arr_pv, auto_monitor=False)
+            zerostr = PV(pvnames.char_arr_pv, auto_monitor=False)
             zerostr.wait_for_connection()
 
             # elem_count = 128, requested count = None, libca returns count = 1
@@ -419,13 +419,14 @@ class PV_Tests(unittest.TestCase):
             numpy.testing.assert_array_equal(zerostr.get(as_string=False), [0, 0])
             self.assertEquals(zerostr.get(as_string=True, as_numpy=False), '')
             numpy.testing.assert_array_equal(zerostr.get(as_string=False, as_numpy=False), [0, 0])
+            zerostr.disconnect()
 
     def test_emptyish_char_waveform_monitor(self):
         '''a test of a char waveform of length 1 (NORD=1): value "\0"
         with using auto_monitor
         '''
         with no_simulator_updates():
-            zerostr = get_pv(pvnames.char_arr_pv, auto_monitor=True)
+            zerostr = PV(pvnames.char_arr_pv, auto_monitor=True)
             zerostr.wait_for_connection()
 
             zerostr.put([0], wait=True)
@@ -443,6 +444,7 @@ class PV_Tests(unittest.TestCase):
             numpy.testing.assert_array_equal(zerostr.get(as_string=False), [0, 0])
             self.assertEquals(zerostr.get(as_string=True, as_numpy=False), '')
             numpy.testing.assert_array_equal(zerostr.get(as_string=False, as_numpy=False), [0, 0])
+            zerostr.disconnect()
 
     def testEnumPut(self):
         pv = get_pv(pvnames.enum_pv)

--- a/tests/test_cas.py
+++ b/tests/test_cas.py
@@ -65,7 +65,7 @@ def softioc():
         df.write(cas_test_db)
         df.flush()
 
-        proc = subprocess.Popen(['softIoc', '-D', 
+        proc = subprocess.Popen(['softIoc', '-D',
                                  '/home/travis/mc/envs/testenv/epics/dbd/softIoc.dbd',
                                  '-m', 'P=test', '-a', cf.name,
                                  '-d', df.name],
@@ -82,7 +82,7 @@ def pvs():
               'test:permit']
     pvs = dict()
     for name in pvlist:
-        pv = epics.PV(name)
+        pv = epics.get_pv(name)
         pv.wait_for_connection()
         pvs[pv.pvname] = pv
 
@@ -126,7 +126,7 @@ def test_pv_access_event_callback(softioc, pvs):
         assert pv.write_access == write_access
         pv.flag = True
 
-    bo = epics.PV('test:bo', access_callback=lcb)
+    bo = epics.get_pv('test:bo', access_callback=lcb)
     bo.flag = False
 
     # set the run-permit to trigger an access rights event

--- a/tests/test_cas.py
+++ b/tests/test_cas.py
@@ -134,6 +134,8 @@ def test_pv_access_event_callback(softioc, pvs):
     assert pvs['test:permit'].get(as_string=True, use_monitor=False) == 'ENABLED'
 
     assert bo.flag is True
+    bo.access_callbacks = []
+
 
 def test_ca_access_event_callback(softioc, pvs):
     # clear the run-permit

--- a/tests/test_cas.py
+++ b/tests/test_cas.py
@@ -74,8 +74,12 @@ def softioc():
                                  stdout=subprocess.PIPE)
         yield proc
 
-        proc.kill()
-        proc.wait()
+        try:
+            proc.kill()
+            proc.wait()
+        except OSError:
+            pass
+
 
 @pytest.yield_fixture(scope='module')
 def pvs():

--- a/tests/test_multiprocessing.py
+++ b/tests/test_multiprocessing.py
@@ -10,7 +10,7 @@ PVN2 = pvnames.double_pv2 # 'Py:ao3'
 
 def subprocess(*args):
     print('==subprocess==', args)
-    mypvs = [epics.PV(pvname) for pvname in args]
+    mypvs = [epics.get_pv(pvname) for pvname in args]
 
     for i in range(10):
         time.sleep(0.750)
@@ -23,7 +23,7 @@ def main_process():
         print('--main:monitor %s=%s' % (pvname, char_value))
 
     print('--main:')
-    pv1 = epics.PV(PVN1)
+    pv1 = epics.get_pv(PVN1)
     print('--main:init %s=%s' % (PVN1, pv1.get()))
     pv1.add_callback(callback=monitor)
 

--- a/tests/test_threading.py
+++ b/tests/test_threading.py
@@ -7,7 +7,7 @@ def test_basic_thread():
     result = []
     def thread():
         epics.ca.use_initial_context()
-        pv = epics.PV(pvnames.double_pv)
+        pv = epics.get_pv(pvnames.double_pv)
         result.append(pv.get())
 
     epics.ca.use_initial_context()
@@ -21,7 +21,7 @@ def test_basic_thread():
 def test_basic_cathread():
     result = []
     def thread():
-        pv = epics.PV(pvnames.double_pv)
+        pv = epics.get_pv(pvnames.double_pv)
         result.append(pv.get())
 
     epics.ca.use_initial_context()
@@ -36,13 +36,13 @@ def test_attach_context():
     result = []
     def thread():
         epics.ca.create_context()
-        pv = epics.PV(pvnames.double_pv2)
+        pv = epics.get_pv(pvnames.double_pv2)
         assert pv.wait_for_connection()
         result.append(pv.get())
         epics.ca.detach_context()
 
         epics.ca.attach_context(ctx)
-        pv = epics.PV(pvnames.double_pv)
+        pv = epics.get_pv(pvnames.double_pv)
         assert pv.wait_for_connection()
         result.append(pv.get())
 
@@ -62,7 +62,7 @@ def test_pv_from_main():
         result.append(pv.get())
 
     epics.ca.use_initial_context()
-    pv = epics.PV(pvnames.double_pv2)
+    pv = epics.get_pv(pvnames.double_pv2)
 
     t = epics.ca.CAThread(target=thread)
     t.start()


### PR DESCRIPTION
The overall goal of this PR is to fix `clear_channel` not clearing the cache appropriately. This meant that subsequent calls to `create_channel` after `clear_channel` could return a stale `chid` and cause a segfault. 

Fixing the above uncovered an atexit cleanup bug (with `finalize_libca`) where channels could potentially get cleared twice, causing a segfault.

I believe this PR now addresses both of the above. Additional changes and details are as follows:

* Also adds a simple repr for further debugging of cache-related things.
* Removed the `_get_or_create_*` methods after thinking more about how `create_channel` operates 
    - This simplifies things considerably, and almost everything goes through `get_cache` now.
* Add a `channel id` cache (`epics.ca._chid_cache`).
    - `chid` is effectively a pointer, so we're guaranteed it'll be unique
    - Due to the inner-workings of `caget` and such, we still need the `context + pvname` cache (that is, the user calls `caget` with a pvname, and we need to handle the channel id mapping behind the scenes)
    - I should not have doubted @dchabot previously - it turns out that access rights callbacks are _not always_ called from a thread with a CA context attached. I don't know why this is, but this cache works around it.
   - I believe that there were multiple cache items being created due to the access rights event popping up in a different (i.e., null) context, which created a different cache item. That meant we called `clear_channel` twice at exit.
* Tests were updated, where possible, to use `get_pv` instead of creating their own `PV` instance.
* Last but not least: closes #163 - the new `chid` cache made solving this rather easy. The issue is that disconnection callbacks also do not happen in a CA context, and we did not have test coverage of that.