### PR TITLE
BLD: if using NOLIBCA do not install epics.clibs

### DIFF
--- a/epics/ca.py
+++ b/epics/ca.py
@@ -232,11 +232,15 @@ def _find_lib(inp_lib_name):
             os.path.isfile(dllpath)):
         return dllpath
 
-    # Test 2: look in installed python location for dll
-    dllpath = resource_filename('epics.clibs', clib_search_path(inp_lib_name))
+    try:
+        # Test 2: look in installed python location for dll
+        dllpath = resource_filename('epics.clibs',
+                                    clib_search_path(inp_lib_name))
 
-    if (os.path.exists(dllpath) and os.path.isfile(dllpath)):
-        return dllpath
+        if (os.path.exists(dllpath) and os.path.isfile(dllpath)):
+            return dllpath
+    except ModuleNotFoundError:
+        pass
 
     # Test 3: look through Python path and PATH env var for dll
     path_sep = ':'

--- a/setup.py
+++ b/setup.py
@@ -46,8 +46,10 @@ nolibca = os.environ.get('NOLIBCA', None)
 if nolibca is None:
     pkg_data = {'epics.clibs': ['darwin64/*', 'linux64/*', 'linux32/*',
                                 'linuxarm/*', 'win32/*', 'win64/*']}
+    extra_pkgs = ['epics.clibs']
 else:
     pkg_data = dict()
+    extra_pkgs = []
 
 PY_MAJOR, PY_MINOR = sys.version_info[:2]
 if PY_MAJOR == 2 and PY_MINOR < 6:
@@ -72,7 +74,7 @@ setup(name = 'pyepics',
                       'Programming Language :: Python',
                       'Topic :: Scientific/Engineering'],
       packages = ['epics','epics.wx','epics.devices', 'epics.compat',
-                  'epics.autosave', 'epics.clibs'],
+                  'epics.autosave'] + extra_pkgs,
       package_data = pkg_data,
      )
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,6 +1,6 @@
 import pytest
 import os
-import sys 
+import sys
 import re
 
 import epics
@@ -12,14 +12,14 @@ pytestmark = pytest.mark.skipif(os.getenv('TRAVIS') is None,
 
 def test_libca_init():
     assert epics.ca.initialize_libca()
-    
+
 # Skip if Travis defines NOLIBCA
 @pytest.mark.skipif(os.getenv('NOLIBCA') is not None,
                     reason='NOLIBCA is defined')
 def test_install_encapsulation():
     libca = epics.ca.find_libca()
     system = sys.platform
-    
+
     if 'linux' in system:
         assert re.search('.*/epics/clibs/.*/libca\.so$', libca)
     elif 'darwin' in system:
@@ -33,14 +33,5 @@ def test_install_encapsulation():
 @pytest.mark.skipif(os.getenv('NOLIBCA') is None,
                     reason='NOLIBCA is not defined')
 def test_install_no_libs():
-    libca = epics.ca.find_libca()
-    system = sys.platform
-
-    if 'linux' in system:
-        assert re.search('.*/epics/clibs/.*/libca\.so$', libca) is None
-    elif 'darwin' in system:
-        assert re.search('.*/epics/clibs/.*/libca\.dylib$', libca) is None
-    elif 'win' in system:
-        assert re.search('.*\epics\clibs\.*/ca\\.dll$', libca) is None
-    else:
-        raise 'Are you using BSD? You are hardcore...'
+    with pytest.raises(ImportError):
+        import epics.clibs


### PR DESCRIPTION
Replaces PR #160 which was erroneously closed.

Opinions differ if pyepics should be shipping pre-built binaries directly in the package or not.  If we accept the position that there exist reasonable people do not want the binaries (which is what I thought the consensus in https://github.com/pyepics/pyepics/pull/83/ was), then pyepics should not be installing vestigial empty sub-modules in the case where they are not included.

I would like this merged for 3.4.0