### PR TITLE
FIX: replace connection callback poll() with sleep()

### DIFF
--- a/epics/ca.py
+++ b/epics/ca.py
@@ -252,7 +252,10 @@ class _CacheItem:
         chid_int = self.chid_int
         for callback in list(self.callbacks):
             if callable(callback):
-                poll()
+                # The following sleep is here only to allow other threads the
+                # opportunity to grab the Python GIL. (see pyepics/pyepics#171)
+                time.sleep(0)
+
                 # print( ' ==> connection callback ', callback, conn)
                 callback(pvname=self.pvname, chid=chid_int, conn=self.conn)
 


### PR DESCRIPTION
Closes #171

libca apparently(erroneously) leaks UDP sockets when calling `poll` in a connection callback thread. More details and debugging information in #171.