### PR TITLE
Fix problem with listing attributes in python3 in __dir__() method

### DIFF
--- a/epics/device.py
+++ b/epics/device.py
@@ -303,9 +303,9 @@ class Device(object):
 
     def __dir__(self):
         # there's no cleaner method to do this until Python 3.3
-        all_attrs = set(self._aliases.keys() + self._pvs.keys() +
+        all_attrs = set(list(self._aliases.keys()) + list(self._pvs.keys()) +
                         list(self._nonpvs) +
-                        self.__dict__.keys() + dir(Device))
+                        list(self.__dict__.keys()) + dir(Device))
         return list(sorted(all_attrs))
 
     def __repr__(self):


### PR DESCRIPTION
## Description

The __dir__() method of epics.Device() was concatenating dictionary keys and lists. This is fine under python2, but broke in later versions of python3. Convert the dict_keys iterables to lists to fix the problem transparently for py2 and py3. Maybe there is a better solution for this, but the quick fix in this pull request seems to solve the problem for now.

This solution has not yet been tested on all versions!

I have not checked whether similar problems would potentially arrise in other modules.

