### PR TITLE
Misc updates

### DIFF
--- a/epics/alarm.py
+++ b/epics/alarm.py
@@ -30,7 +30,7 @@ class Alarm(object):
        alert_delay    time (in seconds) to stay quiet after executing a callback.
                       this is a minimum time, as it is checked only when a PVs
                       value actually changes.  See note below.
-       
+
     example:
        >>> from epics import alarm, poll
        >>> def alarmHandler(pvname=None, value=None, **kw):
@@ -44,7 +44,7 @@ class Alarm(object):
        >>>     poll()
 
     when 'XX.VAL' exceeds (is 'gt') 2.0, the alarmHandler will be called.
-    
+
     notes:
       alarm_delay:  The alarm delay avoids over-notification by specifying a
 
@@ -52,18 +52,18 @@ class Alarm(object):
                     sent, even if a value is changing and out-of-range.  Since
                     Epics callback are used to process events, the alarm state
                     will only be checked when a PV's value changes.
-                    
+
       callback function:  the user-supplied callback function should be prepared
                     for a large number of keyword arguments: use **kw!!!
                     For further explanation, see notes in pv.py.
-                
+
                     These keyword arguments will always be included:
-                    
+
                     pvname      name of PV
                     value       current value of PV
                     char_value  text string for PV
                     trip_point  will hold the trip point used to define 'out of range'
-                    comparison  string 
+                    comparison  string
                     self.user_callback(pvname=pvname, value=value,
                                    char_value=char_value,
                                    trip_point=self.trip_point,
@@ -82,7 +82,7 @@ class Alarm(object):
            '>=': operator.__ge__,
            'gt': operator.__gt__,
            '>' : operator.__gt__ }
-    
+
     def __init__(self, pvname, comparison=None, trip_point=None,
                  callback=None, alert_delay=10):
 
@@ -91,12 +91,12 @@ class Alarm(object):
         elif is_string(pvname):
             self.pv = pv.get_pv(pvname)
             self.pv.connect()
-        
+
         if self.pv is None or comparison is None or trip_point is None:
             msg = 'alarm requires valid PV, comparison, and trip_point'
             raise UserWarning(msg)
-      
-       
+
+
         self.trip_point = trip_point
 
         self.last_alert  = 0
@@ -105,27 +105,27 @@ class Alarm(object):
 
         self.cmp = None
         self.comp_name = 'Not Defined'
-        if hasattr(comparison, '__call__'):
+        if callable(comparison):
             self.comp_name  = comparison.__name__
-            self.cmp = comparison            
+            self.cmp = comparison
         elif comparison is not None:
             self.cmp   = self.ops.get(comparison.replace('_', ''), None)
             if self.cmp is not None:
                 self.comp_name  = comparison
-            
+
         self.alarm_state = False
         self.pv.add_callback(self.check_alarm)
         self.check_alarm()
-        
+
     def __repr__(self):
         return "<Alarm '%s', comp=%s, trip_point=%s >" % (self.pv.name,
                                                           self.comp_name,
                                                           self.trip_point)
     def reset(self):
-        "resets the alarm state" 
+        "resets the alarm state"
         self.last_alert = 0
         self.alarm_state = False
-    
+
     def check_alarm(self, pvname=None, value=None, char_value=None, **kw):
         """checks alarm status, act if needed.
         """
@@ -138,19 +138,17 @@ class Alarm(object):
         old_alarm_state  = self.alarm_state
         self.alarm_state =  self.cmp(val, self.trip_point)
 
-        now = time.time()        
+        now = time.time()
 
         if (self.alarm_state and not old_alarm_state and
             ((now - self.last_alert) > self.alert_delay)) :
             self.last_alert = now
-            if hasattr(self.user_callback, '__call__'):
+            if callable(self.user_callback):
                 self.user_callback(pvname=pvname, value=value,
                                    char_value=char_value,
                                    trip_point=self.trip_point,
                                    comparison=self.comp_name, **kw)
-                
+
             else:
                 sys.stdout.write('Alarm: %s=%s (%s)\n' % (pvname, char_value,
                                                           time.ctime()))
-
-

--- a/epics/pv.py
+++ b/epics/pv.py
@@ -237,9 +237,9 @@ class PV(object):
         self._conn_started = False
         if isinstance(callback, (tuple, list)):
             for i, thiscb in enumerate(callback):
-                if hasattr(thiscb, '__call__'):
+                if callable(thiscb):
                     self.callbacks[i] = (thiscb, {})
-        elif hasattr(callback, '__call__'):
+        elif callable(callback):
             self.callbacks[0] = (callback, {})
 
         self.chid = None
@@ -322,7 +322,7 @@ class PV(object):
             self._check_auto_monitor()
 
         for conn_cb in self.connection_callbacks:
-            if hasattr(conn_cb, '__call__'):
+            if callable(conn_cb):
                 conn_cb(pvname=self.pvname, conn=conn, pv=self)
             elif not conn and self.verbose:
                 ca.write("PV '%s' disconnected." % pvname)
@@ -793,7 +793,7 @@ class PV(object):
         kwd = copy.copy(self._args)
         kwd.update(kwargs)
         kwd['cb_info'] = (index, self)
-        if hasattr(fcn, '__call__'):
+        if callable(fcn):
             fcn(**kwd)
 
     def add_callback(self, callback=None, index=None, run_now=False,
@@ -805,7 +805,7 @@ class PV(object):
         Note that a PV may have multiple callbacks, so that each
         has a unique index (small integer) that is returned by
         add_callback.  This index is needed to remove a callback."""
-        if hasattr(callback, '__call__'):
+        if callable(callback):
             if index is None:
                 index = 1
                 if len(self.callbacks) > 0:

--- a/epics/pv.py
+++ b/epics/pv.py
@@ -892,8 +892,14 @@ class PV(object):
             if len(self.callbacks) > 0:
                 for nam in sorted(self.callbacks.keys()):
                     cback = self.callbacks[nam][0]
-                    out.append('      %s in file %s' % (cback.func_name,
-                                        cback.func_code.co_filename))
+                    cbname = getattr(cback, 'func_name', None)
+                    if cbname is None:
+                        cbname = getattr(cback, '__name__', repr(cback))
+                    cbcode = getattr(cback, 'func_code', None)
+                    if cbcode is None:
+                        cbcode = getattr(cback, '__code__', None)
+                    cbfile = getattr(cbcode, 'co_filename', '?')
+                    out.append('      %s in file %s' % (cbname, cbfile))
         else:
             out.append('   PV is NOT internally monitored')
         out.append('=============================')

--- a/epics/wx/motorpanel.py
+++ b/epics/wx/motorpanel.py
@@ -40,7 +40,7 @@ class MotorPanel(wx.Panel):
         wx.Panel.__init__(self, parent, style=wx.TAB_TRAVERSAL)
         self.parent = parent
 
-        if hasattr(messenger, '__call__'):
+        if callable(messenger):
             self.__messenger = messenger
 
         self.format = None

--- a/epics/wx/utils.py
+++ b/epics/wx/utils.py
@@ -88,7 +88,7 @@ def pack(window, sizer):
 def add_button(parent, label, size=(-1, -1), action=None):
     "add simple button with bound action"
     thisb = wx.Button(parent, label=label, size=size)
-    if hasattr(action, '__call__'):
+    if callable(action):
         thisb.Bind(wx.EVT_BUTTON, action)
     return thisb
 
@@ -96,7 +96,7 @@ def add_menu(parent, menu, label='', text='', action=None):
     "add submenu"
     wid = wx.NewId()
     menu.Append(wid, label, text)
-    if hasattr(action, '__call__'):
+    if callable(action):
         parent.Bind(wx.EVT_MENU, action, id=wid)
 
 def popup(parent, message, title, style=None):
@@ -215,7 +215,7 @@ class Closure:
 
     def __call__(self,  *args, **kws):
         self.kws.update(kws)
-        if hasattr(self.func, '__call__'):
+        if callable(self.func):
             self.args = args
             return self.func(*self.args, **self.kws)
 
@@ -276,7 +276,7 @@ class FloatCtrl(wx.TextCtrl):
 
     def SetAction(self, action, **kws):
         "set callback action"
-        if hasattr(action,'__call__'):
+        if callable(action):
             self.__action = Closure(action, **kws)
 
     def SetPrecision(self, prec=0):
@@ -308,7 +308,7 @@ class FloatCtrl(wx.TextCtrl):
         if value is not None:
             wx.TextCtrl.SetValue(self, self.format % value)
 
-        if self.is_valid and hasattr(self.__action, '__call__') and act:
+        if self.is_valid and callable(self.__action) and act:
             self.__action(value=self.__val)
         elif not self.is_valid and self.bell_on_invalid:
             wx.Bell()
@@ -318,7 +318,7 @@ class FloatCtrl(wx.TextCtrl):
     def OnKillFocus(self, event):
         "focus lost"
         self.__GetMark()
-        if self.act_on_losefocus and hasattr(self.__action, '__call__'):
+        if self.act_on_losefocus and callable(self.__action):
             self.__action(value=self.__val)
         event.Skip()
 

--- a/epics/wx/wxlib.py
+++ b/epics/wx/wxlib.py
@@ -886,7 +886,7 @@ class PVCheckBox(wx.CheckBox, PVCtrlMixin):
             self.Value = (value == self.on_value)
         else:
             self.Value = bool(self.pv.get())
-        if hasattr(self.OnChange, '__call__'):
+        if callable(self.OnChange):
             self.OnChange(self)
 
     @EpicsFunction


### PR DESCRIPTION
This adds two small fixes for maintenance, should give no change in functionality:

 a) replace `hasattr(obj, '__call__')` with `callable(obj)`.  I forget which early version of Python 3 required the uglier form, but `callable` has been supported for many versions now.

b) use modern forms of "get function name" and "get filename of function" so that these can be reported with `PV.info`.