### PR TITLE
explicitly unpack access bits, as required for Py3.7.6

### DIFF
--- a/epics/ca.py
+++ b/epics/ca.py
@@ -747,9 +747,9 @@ def _onAccessRightsEvent(args):
         entry = _chid_cache[_chid_to_int(args.chid)]
     except KeyError:
         return
-
-    entry.run_access_event_callbacks(
-        bool(args.read_access), bool(args.write_access))
+    read = bool(args.access & 1)
+    write = bool((args.access >> 1) & 1)
+    entry.run_access_event_callbacks(read, write)
 
 
 # create global reference to these callbacks

--- a/epics/ca.py
+++ b/epics/ca.py
@@ -747,9 +747,9 @@ def _onAccessRightsEvent(args):
         entry = _chid_cache[_chid_to_int(args.chid)]
     except KeyError:
         return
-
-    entry.run_access_event_callbacks(
-        bool(args.read_access), bool(args.write_access))
+    read = bool(args.access % 2)
+    write = bool(args.access>=2)
+    entry.run_access_event_callbacks(read, write)
 
 
 # create global reference to these callbacks
@@ -757,8 +757,7 @@ _CB_CONNECT = dbr.make_callback(_onConnectionEvent, dbr.connection_args)
 _CB_PUTWAIT = dbr.make_callback(_onPutEvent,        dbr.event_handler_args)
 _CB_GET     = dbr.make_callback(_onGetEvent,        dbr.event_handler_args)
 _CB_EVENT   = dbr.make_callback(_onMonitorEvent,    dbr.event_handler_args)
-_CB_ACCESS  = dbr.make_callback(_onAccessRightsEvent,
-                                dbr.access_rights_handler_args)
+_CB_ACCESS  = dbr.make_callback(_onAccessRightsEvent,  dbr.access_rights_handler_args)
 
 # Now we're ready to wrap libca functions
 #

--- a/epics/ca.py
+++ b/epics/ca.py
@@ -747,9 +747,9 @@ def _onAccessRightsEvent(args):
         entry = _chid_cache[_chid_to_int(args.chid)]
     except KeyError:
         return
-    read = bool(args.access % 2)
-    write = bool(args.access>=2)
-    entry.run_access_event_callbacks(read, write)
+
+    entry.run_access_event_callbacks(
+        bool(args.read_access), bool(args.write_access))
 
 
 # create global reference to these callbacks
@@ -757,7 +757,8 @@ _CB_CONNECT = dbr.make_callback(_onConnectionEvent, dbr.connection_args)
 _CB_PUTWAIT = dbr.make_callback(_onPutEvent,        dbr.event_handler_args)
 _CB_GET     = dbr.make_callback(_onGetEvent,        dbr.event_handler_args)
 _CB_EVENT   = dbr.make_callback(_onMonitorEvent,    dbr.event_handler_args)
-_CB_ACCESS  = dbr.make_callback(_onAccessRightsEvent,  dbr.access_rights_handler_args)
+_CB_ACCESS  = dbr.make_callback(_onAccessRightsEvent,
+                                dbr.access_rights_handler_args)
 
 # Now we're ready to wrap libca functions
 #

--- a/epics/dbr.py
+++ b/epics/dbr.py
@@ -356,8 +356,8 @@ class connection_args(ctypes.Structure):
 class access_rights_handler_args(ctypes.Structure):
     "access rights arguments"
     _fields_ = [('chid', chid_t),
-                ('read_access', ctypes.c_char),
-                ('write_access', ctypes.c_char)]
+                ('read_access', ctypes.c_bool),
+                ('write_access', ctypes.c_bool)]
 
 if PY64_WINDOWS and PY_MAJOR == 2:
     # need to add padding on 64-bit Windows for Python2 -- yuck!

--- a/epics/dbr.py
+++ b/epics/dbr.py
@@ -357,7 +357,7 @@ class connection_args(ctypes.Structure):
 class access_rights_handler_args(ctypes.Structure):
     "access rights arguments"
     _fields_ = [('chid', chid_t),
-                ('access', ctypes.c_ubyte)]
+                ('access', ubyte_t)]
 
 if PY64_WINDOWS and PY_MAJOR == 2:
     # need to add padding on 64-bit Windows for Python2 -- yuck!
@@ -382,5 +382,4 @@ if PY64_WINDOWS and PY_MAJOR == 2:
         "access rights arguments"
         _fields_ = [('chid', chid_t),
                     ('_pad_',ctypes.c_int8),
-                    ('read_access', uint_t, 1),
-                    ('write_access', uint_t, 1)]
+                    ('access', ubyte_t)]

--- a/epics/dbr.py
+++ b/epics/dbr.py
@@ -353,11 +353,11 @@ class connection_args(ctypes.Structure):
     _fields_ = [('chid', chid_t),
                 ('op', long_t)]
 
+
 class access_rights_handler_args(ctypes.Structure):
     "access rights arguments"
     _fields_ = [('chid', chid_t),
-                ('read_access', ctypes.c_bool),
-                ('write_access', ctypes.c_bool)]
+                ('access', ctypes.c_ubyte)]
 
 if PY64_WINDOWS and PY_MAJOR == 2:
     # need to add padding on 64-bit Windows for Python2 -- yuck!

--- a/epics/dbr.py
+++ b/epics/dbr.py
@@ -356,7 +356,8 @@ class connection_args(ctypes.Structure):
 class access_rights_handler_args(ctypes.Structure):
     "access rights arguments"
     _fields_ = [('chid', chid_t),
-                ('access', uint_t)]
+                ('read_access', ctypes.c_char),
+                ('write_access', ctypes.c_char)]
 
 if PY64_WINDOWS and PY_MAJOR == 2:
     # need to add padding on 64-bit Windows for Python2 -- yuck!

--- a/epics/dbr.py
+++ b/epics/dbr.py
@@ -356,8 +356,7 @@ class connection_args(ctypes.Structure):
 class access_rights_handler_args(ctypes.Structure):
     "access rights arguments"
     _fields_ = [('chid', chid_t),
-                ('read_access', uint_t, 1),
-                ('write_access', uint_t, 1)]
+                ('access', uint_t)]
 
 if PY64_WINDOWS and PY_MAJOR == 2:
     # need to add padding on 64-bit Windows for Python2 -- yuck!


### PR DESCRIPTION
## Description
<!--- Describe the changes your Pull Request would make, especially describing  what problem it is meant to solve -->
This changes the ctypes structure definition for `access_rights_handler_args` to explicitly unpack the read/write access bit fields.

<!--- If it fixes an open issue, please link to the issue here. -->

An attempt to fix #189 

<!--- If it fixes a problem that has not been opened as a Github Issue, consider opening one. -->
<!--- If appropriate, provide a link to a related discussion on the Tech-Talk mailing list. -->
