### PR TITLE
return -1 instead of None if caput times out on disconnected PV

### DIFF
--- a/epics/__init__.py
+++ b/epics/__init__.py
@@ -66,6 +66,8 @@ def caput(pvname, value, wait=False, timeout=60):
     if thispv.connected:
         timeout -= (time.time() - start_time)
         return thispv.put(value, wait=wait, timeout=timeout)
+    else:
+        return -1
 
 def caget(pvname, as_string=False, count=None, as_numpy=True,
           use_monitor=False, timeout=5.0):


### PR DESCRIPTION
## Description
<!--- Describe the changes your Pull Request would make, especially describing  what problem it is meant to solve -->
caputs to nonexistent/disconnected PVs currently return None instead of -1 like the docs suggest.
<!--- If it fixes an open issue, please link to the issue here. -->
Issue created [here](https://github.com/pyepics/pyepics/issues/198).
<!--- If it fixes a problem that has not been opened as a Github Issue, consider opening one. -->
<!--- If appropriate, provide a link to a related discussion on the Tech-Talk mailing list. -->
