### PR TITLE
fix PV.char_value to return proper string without needing PV.get(as_string=True)

### DIFF
--- a/epics/pv.py
+++ b/epics/pv.py
@@ -930,7 +930,8 @@ class PV(object):
     @property
     def char_value(self):
         "character string representation of value"
-        return self._getarg('char_value')
+        self._getarg('char_value')  # forces lookup of CTRL vars
+        return self._set_charval(self._getarg('value'))
 
     @property
     def status(self):


### PR DESCRIPTION
 Description
<!--- Describe the changes your Pull Request would make, especially describing  what problem it is meant to solve -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it fixes a problem that has not been opened as a Github Issue, consider opening one. -->
<!--- If appropriate, provide a link to a related discussion on the Tech-Talk mailing list. -->

Mixing Issue (from email) and fix: 

    import epics
    p = epics.PV('EnumTypePV')
    p.char_value

will return something like '0' or '1' instead of the enum name, say, 'Infected' or 'VirusFree'.  Of course, doing

    p.get(as_string=True)

will return the proper string representation, and then `p.char_value` will be correct.

This PR fixes that by forcing the `char_value` property to call `PV._set_charval()`.





 