### PR TITLE
FIX: do not block if disconnected when changing auto_monitor settings

### DIFF
--- a/epics/pv.py
+++ b/epics/pv.py
@@ -354,10 +354,13 @@ class PV(object):
 
         Clears or adds monitor, if necessary.
         '''
-        count = self.count
-        chid = self.chid
+        if not self.connected or self.chid is None:
+            # Auto-monitor will be enabled (or toggled based on count) upon the
+            # next connection callback.
+            return
 
-        if count is None or chid is None:
+        count = self.count
+        if count is None:
             return
 
         if self._auto_monitor is None:


### PR DESCRIPTION
## Description
Calling `clear_auto_monitor` when an `epics.PV` is disconnected may cause it to attempt to reconnect when accessing the `count` property.

Detailed in the following traceback:

<details>

```python
Traceback (most recent call last):
  File "/Users/klauer/mc/envs/lucid/lib/python3.6/weakref.py", line 624, in _exitfunc
    f()
  File "/Users/klauer/mc/envs/lucid/lib/python3.6/weakref.py", line 548, in __call__
    return info.func(*info.args, **(info.kwargs or {}))
  File "/Users/klauer/mc/envs/lucid/lib/python3.6/site-packages/ophyd/signal.py", line 1718, in destroy
    self.cl.release_pvs(self._write_pv)
  File "/Users/klauer/mc/envs/lucid/lib/python3.6/site-packages/ophyd/_pyepics_shim.py", line 122, in release_pvs
    pv.clear_auto_monitor()
  File "/Users/klauer/mc/envs/lucid/lib/python3.6/site-packages/epics/pv.py", line 48, in wrapped
    return func(self, *args, **kwargs)
  File "/Users/klauer/mc/envs/lucid/lib/python3.6/site-packages/epics/pv.py", line 444, in clear_auto_monitor
    self.auto_monitor = False
  File "/Users/klauer/mc/envs/lucid/lib/python3.6/site-packages/epics/pv.py", line 48, in wrapped
    return func(self, *args, **kwargs)
  File "/Users/klauer/mc/envs/lucid/lib/python3.6/site-packages/epics/pv.py", line 409, in auto_monitor
    self._check_auto_monitor()
  File "/Users/klauer/mc/envs/lucid/lib/python3.6/site-packages/epics/pv.py", line 48, in wrapped
    return func(self, *args, **kwargs)
  File "/Users/klauer/mc/envs/lucid/lib/python3.6/site-packages/epics/pv.py", line 357, in _check_auto_monitor
    count = self.count
  File "/Users/klauer/mc/envs/lucid/lib/python3.6/site-packages/epics/pv.py", line 962, in count
    return self._getarg('count')
  File "/Users/klauer/mc/envs/lucid/lib/python3.6/site-packages/ophyd/_pyepics_shim.py", line 92, in _getarg
    self.get_ctrlvars(timeout=1, warn=False)
  File "/Users/klauer/mc/envs/lucid/lib/python3.6/site-packages/epics/pv.py", line 48, in wrapped
    return func(self, *args, **kwargs)
  File "/Users/klauer/mc/envs/lucid/lib/python3.6/site-packages/epics/pv.py", line 729, in get_ctrlvars
    if not self.wait_for_connection():
  File "/Users/klauer/mc/envs/lucid/lib/python3.6/site-packages/epics/pv.py", line 48, in wrapped
    return func(self, *args, **kwargs)
  File "/Users/klauer/mc/envs/lucid/lib/python3.6/site-packages/epics/pv.py", line 422, in wait_for_connection
    self.connect(timeout=timeout)
  File "/Users/klauer/mc/envs/lucid/lib/python3.6/site-packages/epics/pv.py", line 48, in wrapped
    return func(self, *args, **kwargs)
  File "/Users/klauer/mc/envs/lucid/lib/python3.6/site-packages/epics/pv.py", line 437, in connect
    ca.connect_channel(self.chid, timeout=timeout)
  File "/Users/klauer/mc/envs/lucid/lib/python3.6/site-packages/epics/ca.py", line 522, in wrapper
    return fcn(*args, **kwds)
  File "/Users/klauer/mc/envs/lucid/lib/python3.6/site-packages/epics/ca.py", line 1005, in connect_channel
    poll()
  File "/Users/klauer/mc/envs/lucid/lib/python3.6/site-packages/epics/ca.py", line 496, in wrapper
    return fcn(*args, **kwds)
  File "/Users/klauer/mc/envs/lucid/lib/python3.6/site-packages/epics/ca.py", line 856, in poll
    pend_event(evt)
  File "/Users/klauer/mc/envs/lucid/lib/python3.6/site-packages/epics/ca.py", line 843, in pend_event
    ret = libca.ca_pend_event(timeout)
KeyboardInterrupt
```
</details>