### PR TITLE
Prevent exceptions after libca is finalized during teardown

### DIFF
--- a/epics/ca.py
+++ b/epics/ca.py
@@ -545,9 +545,7 @@ def withCA(fcn):
         if libca is None:
             initialize_libca()
         elif libca is _LIBCA_FINALIZED:
-            # See what happens if you uncomment this instead:
-            # initialize_libca()
-            raise RuntimeError('libca shutting down')
+            return  # Avoid raising exceptions when Python shutting down
         return fcn(*args, **kwds)
     return wrapper
 
@@ -563,6 +561,10 @@ def withCHID(fcn):
     @functools.wraps(fcn)
     def wrapper(*args, **kwds):
         "withCHID wrapper"
+        global libca
+        if libca is _LIBCA_FINALIZED:
+            return  # Avoid raising exceptions when Python shutting down
+
         if len(args)>0:
             chid = args[0]
             args = list(args)
@@ -587,6 +589,10 @@ def withConnectedCHID(fcn):
     @functools.wraps(fcn)
     def wrapper(*args, **kwds):
         "withConnectedCHID wrapper"
+        global libca
+        if libca is _LIBCA_FINALIZED:
+            return  # Avoid raising exceptions when Python shutting down
+
         if len(args)>0:
             chid = args[0]
             args = list(args)
@@ -613,6 +619,10 @@ def withMaybeConnectedCHID(fcn):
     @functools.wraps(fcn)
     def wrapper(*args, **kwds):
         "withMaybeConnectedCHID wrapper"
+        global libca
+        if libca is _LIBCA_FINALIZED:
+            return  # Avoid raising exceptions when Python shutting down
+
         if len(args)>0:
             chid = args[0]
             args = list(args)


### PR DESCRIPTION
## Description

This PR builds on @klauer's suggested fix for an issue that began in https://github.com/bluesky/ophyd/issues/834 and resurfaced in https://github.com/bluesky/ophyd/pull/866. This also affected several downstream projects, which began seeing unexpected exceptions in their test suites.

The issue occurs when Python is shutting down. Since the order in which Python tears everything down is not very consistent or controllable, libca is sometimes finalized before downstream code has a chance to run its cleanup. When that cleanup later invokes pyepics functionality that requires libca, exceptions are thrown. Some of them cannot be caught.

An example of this can be triggered by running the following snippet against the current master:

```python
import epics

class Broken:
    def __init__(self, pv):
        self.pv = epics.get_pv(pv)
    def __del__(self):
        self.pv.clear_auto_monitor()

mypv = Broken('sim:mtr1')
``` 

This causes a `ChannelAccessException`, which can be caught. But also prints `ImportError` and `KeyError` tracebacks, which cannot be caught.

Ken's commit replaces this behavior with a single RuntimeError, raised in `@withCA`, which can be caught.

My commit modifies this to:

1. Simply `return` instead of raising a RuntimeError
2. Also do the same in the various `@with...CHID` decorators

This means that any function using `@withCA` or any of the CHID decorators will silently do nothing and return `None` if `finalize_libca` has been called. I realize this is an aggressive thing to do, and it would be fair to argue that client code should just `try` and catch the exceptions instead. My rationale for returning instead is as follows:

If `finalize_libca` has been called, that means `atexit` has been triggered. This means Python is shutting down, and it happened to decide to clean up pyepics before the client code has finished finalizing. There is no way to recover from this; at best client code can ignore the exception and carry on. There's no benefit to forcing client code to wrap all pyepics usage, in any code branch that might be invoked during teardown, in `try: ... except: pass` boilerplate (even functions that don't raise anything under any other circumstance). Philosophically speaking, code using pyepics shouldn't have to worry about an internal dependency of pyepics going away before they were done using pyepics.

The reason for 2. is that many functions only use the CHID decorators (without `@withCA`). And so, for example, calling `epics.ca.clear_channel()` after libca is finalized results in a `ChannelAccessException: Unexpected channel ID` even though the channel ID was previously valid and not yet cleared by client code. This is because `finalize_libca` clears `_chid_cache`.

Whether exception or silent `return`, I think it makes sense to have the same failure behavior from all functions when called after libca is finalized.