### PR TITLE
PycSimpleType appearing in the function native_type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,7 @@ tests/.coverage*
 build
 dist
 NonGit
+venv
+.vscode
+pyepics.egg-info
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,16 @@ script:
   - caget Py:long1
 
   # running tests
-  - py.test -vv -rsx --cov=epics --cov-report term-missing test_install.py ca_unittest.py pv_unittest.py test_pool.py test_threading.py test_cas.py || RESULT=$?
+  - >
+    py.test -vv -rsx --cov=epics --cov-report term-missing
+    test_install.py
+    ca_unittest.py
+    pv_unittest.py
+    test_pool.py
+    test_threading.py
+    test_cas.py
+    test_dbr.py
+    || RESULT=$?
   - if [[ ${RESULT} != 0 ]]; then gdb python core* -ex "thread apply all bt" -ex "set pagination 0" -batch; fi
   - if [[ ${RESULT} != 0 ]]; then exit $RESULT ; fi;
 

--- a/epics/ca.py
+++ b/epics/ca.py
@@ -691,6 +691,10 @@ def _onMonitorEvent(args):
         return
 
     value = dbr.cast_args(args)
+    if value[1] is None:
+        # Cannot process the input becaue casting failed.
+        return
+
     kwds = {'ftype':args.type, 'count':args.count,
             'chid': args.chid, 'pvname': entry.pvname}
 
@@ -739,6 +743,12 @@ def _onGetEvent(args, **kws):
         )
     else:
         result = deepcopy(dbr.cast_args(args))
+        if result[1] is None:
+            result = ChannelAccessGetFailure(
+                'Get failed; unknown type: %d' % args.type,
+                chid=args.chid,
+                status=args.status
+            )
 
     with entry.lock:
         entry.get_results[ftype][0] = result

--- a/epics/dbr.py
+++ b/epics/dbr.py
@@ -297,10 +297,17 @@ def cast_args(args):
 
     If data is already of a native_type, the first
     value in the list will be None.
+
+    If type is not known, both the first and the second
+    value in the list will be None.
     """
     ftype = args.type
     if ftype not in Map:
-        ftype = double_t
+        # Type was not found in the map.
+        # As a consequence, the code cannot
+        # interpret the pointer properly without
+        # a risk of accessing invalid memory area.
+        return [None, None]
 
     ntype = native_type(ftype)
     if ftype != ntype:

--- a/tests/README
+++ b/tests/README
@@ -1,6 +1,6 @@
 This folder contains several tests of the Epics Channel Access Module.
 
-Most of tthese tests require a set of working Epics Channels to run,
+Most of these tests require a set of working Epics Channels to run,
 and assume that the epics database 'pyepics.db' (in Setup/) is being
 run in some local IOC.
 
@@ -19,8 +19,8 @@ to customize in order to properly run these tests.
 The tests are not (yet?) very automated, and the results should be
 inspected for correctness.
 
-Tests using "low level" channel access   
-    ca_unittest1.py               a "unit test" test 
+Tests using "low level" channel access
+    ca_unittest1.py               a "unit test" test
     ca_type_conversion.py
     ca_connection_callback.py
     ca_simpletest.py
@@ -33,7 +33,7 @@ Tests using PV:
     pv_multiple_callbacks.py
     pv_simpletest.py
     pv_type_conversion.py
-    no_monitor.py 
+    no_monitor.py
 
 Connection Tests:
     caget_simple.py

--- a/tests/test_dbr.py
+++ b/tests/test_dbr.py
@@ -1,5 +1,3 @@
-from copy import deepcopy
-import pytest
 import ctypes
 import epics.dbr as dbr
 

--- a/tests/test_dbr.py
+++ b/tests/test_dbr.py
@@ -1,0 +1,32 @@
+from copy import deepcopy
+import pytest
+import ctypes
+import epics.dbr as dbr
+
+
+def _build_args(dbr_type, c_data):
+    args = dbr.event_handler_args()
+    args.type = dbr_type
+    args.count = len(c_data)
+    args.raw_dbr = ctypes.cast(c_data, ctypes.c_void_p)
+    args.status = dbr.ECA_NORMAL
+    return args
+
+
+def test_cast_args():
+    # cast_args casts a single native_type to [None, pointer to the native type]
+    args = _build_args(dbr.DOUBLE, (ctypes.c_double * 1)(3.1415))
+    assert dbr.cast_args(args)[0] is None
+    assert 1 == len(dbr.cast_args(args)[1])
+    assert 3.1415 == dbr.cast_args(args)[1][0]
+
+    # cast_args casts an array of native_type to [None, pointer to the native type]
+    args = _build_args(dbr.DOUBLE, (ctypes.c_double * 4)(1, 2, 3, 5))
+    assert dbr.cast_args(args)[0] is None
+    assert 4 == len(dbr.cast_args(args)[1])
+    assert [1, 2, 3, 5] == [v for v in dbr.cast_args(args)[1]]
+
+    # cast_args casts unknown type to [None, None]
+    args = _build_args(123456789, (ctypes.c_char * 1)(123))
+    assert dbr.cast_args(args)[0] is None
+    assert dbr.cast_args(args)[1] is None


### PR DESCRIPTION
## Description

**Problem**
When a get callback receives a type it does not recognize, it will raise TypeError due to invalid use of type. It is caused by a fallback type instance which not an integer as the rest of the code expects.

**Solution**
1) This update fails casting if the type is not recognized because it is not able to tell much about the supplied memory pointer. In case of `_onGetEvent`, this will yield an error. In case of `_onMonitorEvent` this will end the function silently similar to other cases here.
2) This update adds a unit test which covers the behavior `bdr.cast_args`. This unit test is included into the tests in `.travis.yml`.
3) This update adds `venv` and by-products of vscode and `pip install -e .` into `.gitignore'.

**Test**
1) `test_bdr` was run manually.
2) Updated pyepics was used to retrieve a PV from a running IOC.
