### PR TITLE
FIX memory leak on PV.disconnect() #156

### DIFF
--- a/.github/workflows/test-with-conda.yml
+++ b/.github/workflows/test-with-conda.yml
@@ -35,6 +35,7 @@ jobs:
         python setup.py install
     - name: Run test suite
       run: |
+        python -m pip install psutil
         cd tests/Setup
         export EPICS_CA_ADDR_LIST=localhost
         export EPICS_CA_AUTO_ADDR_LIST=NO

--- a/.github/workflows/test-with-conda.yml
+++ b/.github/workflows/test-with-conda.yml
@@ -59,5 +59,6 @@ jobs:
         coverage run --source=epics -a --timid  -m pytest test_ca_subscribe.py
         coverage run --source=epics -a --timid  -m pytest test_pv_unittests.py
         coverage run --source=epics -a --timid  -m pytest test_pv_typeconversion.py
+        coverage run --source=epics -a --timid  -m pytest test_pv_disconnect.py
         coverage report -m
         bash <(curl -s https://codecov.io/bash)

--- a/tests/test_pv_disconnect.py
+++ b/tests/test_pv_disconnect.py
@@ -5,11 +5,13 @@ from epics import PV
 
 import os
 import psutil
+import pytest
 
 import pvnames
 mypv = pvnames.updating_pv1
 
 
+@pytest.mark.skip(reason="disabled until memleak is fixed")
 def test_memleak_disconnect():
     # try to connect multiple times to the same PV
     mem = []

--- a/tests/test_pv_disconnect.py
+++ b/tests/test_pv_disconnect.py
@@ -51,6 +51,34 @@ def test_reconnect():
     assert value is not None
 
 
+def test_connect_disconnect_with_two_PVs():
+    # create 2 PV objects connecting to the same PV signal
+    pv1 = PV(mypv, auto_monitor=True, callback=lambda **args: ...)
+    pv2 = PV(mypv, auto_monitor=True, callback=lambda **args: ...)
+
+    pv1.wait_for_connection()
+    pv2.wait_for_connection()
+
+    # check that both PVs are connected
+    assert pv1.connect() is True
+    assert pv2.connect() is True
+
+    # check that data is received
+    assert pv1.get() is not None
+    assert pv2.get() is not None
+
+    # disconnect 1 PV
+    pv1.disconnect()
+
+    # check that the first PV is disconnected and doesn't receive data
+    assert pv1.connect() is False
+    assert pv1.get() is None
+
+    # check that the other PV is connected and still receives data
+    assert pv2.connect() is True
+    assert pv2.get() is not None
+
+
 @pytest.mark.skip(reason="disabled until memleak is fixed")
 def test_memleak_disconnect():
     # try to connect multiple times to the same PV

--- a/tests/test_pv_disconnect.py
+++ b/tests/test_pv_disconnect.py
@@ -11,7 +11,6 @@ import pvnames
 mypv = pvnames.updating_pv1
 
 
-@pytest.mark.skip(reason="disabled until memleak is fixed")
 def test_memleak_disconnect():
     # try to connect multiple times to the same PV
     mem = []

--- a/tests/test_pv_disconnect.py
+++ b/tests/test_pv_disconnect.py
@@ -33,6 +33,7 @@ def test_connect_disconnect():
     assert value is None
 
 
+@pytest.mark.skip(reason="disabled until memleak is fixed")
 def test_memleak_disconnect():
     # try to connect multiple times to the same PV
     mem = []

--- a/tests/test_pv_disconnect.py
+++ b/tests/test_pv_disconnect.py
@@ -11,6 +11,27 @@ import pvnames
 mypv = pvnames.updating_pv1
 
 
+def test_connect_disconnect():
+    pv = PV(mypv, auto_monitor=True, callback=lambda **args: ...)
+
+    pv.wait_for_connection()
+
+    # check that PV is connected
+    assert pv.connect() is True
+
+    # check that data is received
+    value = pv.get()
+    assert value is not None
+
+    pv.disconnect()
+
+    # check that PV is disconnected
+    assert pv.connect() is False
+
+    # check that no data is received after disconnect
+    value = pv.get()
+    assert value is None
+
 
 def test_memleak_disconnect():
     # try to connect multiple times to the same PV

--- a/tests/test_pv_disconnect.py
+++ b/tests/test_pv_disconnect.py
@@ -40,11 +40,10 @@ def test_reconnect():
     pv.disconnect()
 
     # try to reconnect to the same PV
-    pv.reconnect()
-    pv.wait_for_connection()
+    connected = pv.reconnect()
 
     # check that PV is connected
-    assert pv.connect() is True
+    assert connected is True
 
     # check that data is received
     value = pv.get()

--- a/tests/test_pv_disconnect.py
+++ b/tests/test_pv_disconnect.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 
 # test of simplest device
-from epics import PV
+from epics import PV, caget
 
 import os
 import psutil
@@ -77,6 +77,31 @@ def test_connect_disconnect_with_two_PVs():
     # check that the other PV is connected and still receives data
     assert pv2.connected is True
     assert pv2.get() is not None
+
+
+def test_connect_disconnect_with_caget():
+    pv = PV(mypv, auto_monitor=True, callback=lambda **args: ...)
+
+    pv.wait_for_connection()
+
+    # check that the PV is connected
+    assert pv.connected is True
+
+    # check that data is received
+    assert pv.get() is not None
+
+    # use caget to get data from the same PV
+    assert caget(mypv) is not None
+
+    # disconnect PV object
+    pv.disconnect()
+
+    # check that the PV is disconnected and doesn't receive data
+    assert pv.connected is False
+    assert pv.get() is None
+
+    # check that you can still use caget to get data from the same PV
+    assert caget(mypv) is not None
 
 
 @pytest.mark.skip(reason="disabled until memleak is fixed")

--- a/tests/test_pv_disconnect.py
+++ b/tests/test_pv_disconnect.py
@@ -33,6 +33,24 @@ def test_connect_disconnect():
     assert value is None
 
 
+def test_reconnect():
+    # connect and disconnect
+    pv = PV(mypv, auto_monitor=True, callback=lambda **args: ...)
+    pv.wait_for_connection()
+    pv.disconnect()
+
+    # try to reconnect to the same PV
+    pv.reconnect()
+    pv.wait_for_connection()
+
+    # check that PV is connected
+    assert pv.connect() is True
+
+    # check that data is received
+    value = pv.get()
+    assert value is not None
+
+
 @pytest.mark.skip(reason="disabled until memleak is fixed")
 def test_memleak_disconnect():
     # try to connect multiple times to the same PV

--- a/tests/test_pv_disconnect.py
+++ b/tests/test_pv_disconnect.py
@@ -1,0 +1,25 @@
+#!/usr/bin/python
+
+# test of simplest device
+from epics import PV
+
+import os
+import psutil
+
+import pvnames
+mypv = pvnames.updating_pv1
+
+
+def test_memleak_disconnect():
+    # try to connect multiple times to the same PV
+    mem = []
+    for i in range(int(2)):
+        for j in range(int(1000)):
+            pv = PV(mypv, auto_monitor=True, callback=lambda **args: ...)
+            pv.disconnect()
+
+        process = psutil.Process(os.getpid())
+        mem.append(process.memory_info().rss)
+
+    # check used memory by the process didn't increase by more than 1%
+    assert mem[1]/mem[0] < 1.01

--- a/tests/test_pv_disconnect.py
+++ b/tests/test_pv_disconnect.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 
 # test of simplest device
-from epics import PV, caget, camonitor, camonitor_clear
+from epics import PV, get_pv, caget, camonitor, camonitor_clear
 
 import os
 import psutil
@@ -78,6 +78,66 @@ def test_connect_disconnect_with_two_PVs():
     # check that the other PV is connected and still receives data
     assert pv2.connected is True
     assert pv2.get() is not None
+
+
+def test_connect_disconnect_with_PV_and_getPV():
+    # create 2 PV objects connecting to the same PV signal, one using PV class and the other one using get_pv()
+    pv1 = PV(mypv, auto_monitor=True, callback=lambda **args: ...)
+    pv2 = get_pv(mypv)
+
+    pv1.wait_for_connection()
+    pv2.wait_for_connection()
+
+    # check that both PVs are connected
+    assert pv1.connected is True
+    assert pv2.connected is True
+
+    # check that data is received
+    assert pv1.get() is not None
+    assert pv2.get() is not None
+
+    # disconnect 1 PV
+    pv1.disconnect()
+
+    time.sleep(1)
+
+    # check that the first PV is disconnected and doesn't receive data
+    assert pv1.connected is False
+    assert pv1.get() is None
+
+    # check that the other PV is connected and still receives data
+    assert pv2.connected is True
+    assert pv2.get() is not None
+
+
+def test_connect_disconnect_with_getPV():
+    # create 2 PV objects connecting to the same PV signal using get_pv()
+    pv1 = get_pv(mypv)
+    pv2 = get_pv(mypv)
+
+    pv1.wait_for_connection()
+    pv2.wait_for_connection()
+
+    # check that both PVs are connected
+    assert pv1.connected is True
+    assert pv2.connected is True
+
+    # check that data is received
+    assert pv1.get() is not None
+    assert pv2.get() is not None
+
+    # disconnect 1 PV
+    pv1.disconnect()
+
+    time.sleep(1)
+
+    # check that the first PV is disconnected and doesn't receive data
+    assert pv1.connected is False
+    assert pv1.get() is None
+
+    # check that the other PV is also disconnected and doesn't receive data either
+    assert pv2.connected is False
+    assert pv2.get() is None
 
 
 def test_connect_disconnect_with_caget():

--- a/tests/test_pv_disconnect.py
+++ b/tests/test_pv_disconnect.py
@@ -5,7 +5,6 @@ from epics import PV, get_pv, caget, camonitor, camonitor_clear
 
 import os
 import psutil
-import pytest
 import time
 
 import pvnames
@@ -34,7 +33,6 @@ def test_connect_disconnect():
     assert value is None
 
 
-@pytest.mark.skip(reason="disabled until disconnect() is fixed")
 def test_reconnect():
     # connect and disconnect
     pv = PV(mypv, auto_monitor=True, callback=lambda **args: ...)
@@ -226,7 +224,6 @@ def test_with_camonitor():
     assert received['flag'] is False
 
 
-@pytest.mark.skip(reason="disabled until memleak is fixed")
 def test_memleak_disconnect():
     # try to connect multiple times to the same PV
     mem = []

--- a/tests/test_pv_disconnect.py
+++ b/tests/test_pv_disconnect.py
@@ -17,7 +17,7 @@ def test_connect_disconnect():
     pv.wait_for_connection()
 
     # check that PV is connected
-    assert pv.connect() is True
+    assert pv.connected is True
 
     # check that data is received
     value = pv.get()
@@ -26,13 +26,14 @@ def test_connect_disconnect():
     pv.disconnect()
 
     # check that PV is disconnected
-    assert pv.connect() is False
+    assert pv.connected is False
 
     # check that no data is received after disconnect
     value = pv.get()
     assert value is None
 
 
+@pytest.mark.skip(reason="disabled until disconnect() is fixed")
 def test_reconnect():
     # connect and disconnect
     pv = PV(mypv, auto_monitor=True, callback=lambda **args: ...)
@@ -59,8 +60,8 @@ def test_connect_disconnect_with_two_PVs():
     pv2.wait_for_connection()
 
     # check that both PVs are connected
-    assert pv1.connect() is True
-    assert pv2.connect() is True
+    assert pv1.connected is True
+    assert pv2.connected is True
 
     # check that data is received
     assert pv1.get() is not None
@@ -70,11 +71,11 @@ def test_connect_disconnect_with_two_PVs():
     pv1.disconnect()
 
     # check that the first PV is disconnected and doesn't receive data
-    assert pv1.connect() is False
+    assert pv1.connected is False
     assert pv1.get() is None
 
     # check that the other PV is connected and still receives data
-    assert pv2.connect() is True
+    assert pv2.connected is True
     assert pv2.get() is not None
 
 

--- a/tests/test_pv_disconnect.py
+++ b/tests/test_pv_disconnect.py
@@ -11,6 +11,7 @@ import pvnames
 mypv = pvnames.updating_pv1
 
 
+
 def test_memleak_disconnect():
     # try to connect multiple times to the same PV
     mem = []

--- a/tests/test_pv_disconnect.py
+++ b/tests/test_pv_disconnect.py
@@ -52,7 +52,7 @@ def test_reconnect():
     assert value is not None
 
 
-def test_connect_disconnect_with_two_PVs():
+def test_with_two_PVs():
     # create 2 PV objects connecting to the same PV signal
     pv1 = PV(mypv, auto_monitor=True, callback=lambda **args: ...)
     pv2 = PV(mypv, auto_monitor=True, callback=lambda **args: ...)
@@ -80,7 +80,7 @@ def test_connect_disconnect_with_two_PVs():
     assert pv2.get() is not None
 
 
-def test_connect_disconnect_with_PV_and_getPV():
+def test_with_PV_and_getPV():
     # create 2 PV objects connecting to the same PV signal, one using PV class and the other one using get_pv()
     pv1 = PV(mypv, auto_monitor=True, callback=lambda **args: ...)
     pv2 = get_pv(mypv)
@@ -110,7 +110,7 @@ def test_connect_disconnect_with_PV_and_getPV():
     assert pv2.get() is not None
 
 
-def test_connect_disconnect_with_getPV():
+def test_with_getPV():
     # create 2 PV objects connecting to the same PV signal using get_pv()
     pv1 = get_pv(mypv)
     pv2 = get_pv(mypv)
@@ -140,7 +140,7 @@ def test_connect_disconnect_with_getPV():
     assert pv2.get() is None
 
 
-def test_connect_disconnect_with_caget():
+def test_with_caget():
     pv = PV(mypv, auto_monitor=True, callback=lambda **args: ...)
     pv.wait_for_connection()
 
@@ -162,7 +162,7 @@ def test_connect_disconnect_with_caget():
     assert caget(mypv) is not None
 
 
-def test_connect_disconnect_with_caget_nomonitor():
+def test_with_caget_nomonitor():
     pv = PV(mypv, auto_monitor=True, callback=lambda **args: ...)
     pv.wait_for_connection()
 
@@ -184,7 +184,7 @@ def test_connect_disconnect_with_caget_nomonitor():
     assert caget(mypv, use_monitor=False) is not None
 
 
-def test_connect_disconnect_with_camonitor():
+def test_with_camonitor():
     pv = PV(mypv, auto_monitor=True, callback=lambda **args: ...)
     pv.wait_for_connection()
 


### PR DESCRIPTION
This PR is a proposal to fix the issue #156 .

The issue occured because the disconnect method left some references to the PV object dangling, which prevented the garbage collector to collect the PV object.

The method behaves otherwise the same as before, i.e. the connection is still cached by epics.ca and reused if a new PV object is created for the same signal.

I also included a set of tests to verify the interaction of the disconnect method with other methods provided by the library.