### PR TITLE
Add setuptools as runtime requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,9 @@ setup(name = 'pyepics',
       packages = ['epics','epics.wx','epics.devices', 'epics.compat',
                   'epics.autosave', 'epics.clibs'],
       package_data = {'epics.clibs': ['darwin64/*', 'linux64/*', 'linux32/*',
-                                      'linuxarm/*', 'win32/*', 'win64/*']})
+                                      'linuxarm/*', 'win32/*', 'win64/*']},
+      install_requires = ['setuptools']
+      )
 
 try:
     libca = epics.ca.find_libca()


### PR DESCRIPTION
setuptools' pkg_resources is used in the ca module, but setuptools was not
 listed as a dependency, yet.

## Description
Add setuptools as a dependency, because pkg_resources is used in epics/ca.py.
This tries to fix issue #224 
Though setuptools is installed most of the time, [pkg_resources does not ship with Python](https://www.python.org/dev/peps/pep-0365/) itself and hence shouldn't been taken for granted.