### PR TITLE
Exclude pyc files recursively

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,4 +9,4 @@ recursive-include conda-recipe *
 recursive-exclude doc/_build *
 recursive-exclude doc *.pdf
 recursive-exclude tests/Misc *
-
+recursive-exclude **/ *.pyc


### PR DESCRIPTION
## Description
Recursively exclude .pyc caching files from being included in source distributions in order to prevent issues with further build tools (like stdeb) or different setups trying to use the cache file though it might not match the current environment.

We were facing the problem that [stdeb](https://github.com/astraw/stdeb) cannot cope with .pyc files being part of the sdist tar.gz.
The newest release on PyPI (https://pypi.org/project/pyepics/#files 3.5.1 https://files.pythonhosted.org/packages/6c/cd/f97b676b6903e6f88bfced3817964559c20a1e3c6cd5244fa188f76fff75/pyepics-3.5.1.tar.gz) includes a `scripts/__pycache__/mpanel.cpython-37.pyc` file, thus causing the issue with stdeb.

As the pyc files are already excluded from the main directory, I guess it is intended, that these files are not part of the sdist—which is afaik best practice anyway.

This fixes [issue #233](https://github.com/pyepics/pyepics/issues/233)