### PR TITLE
Prevented unsubscribing events from a cleared channel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,6 @@ dist
 NonGit
 venv
 .vscode
+.coverage
 pyepics.egg-info
 epics.egg-info

--- a/epics/ca.py
+++ b/epics/ca.py
@@ -12,6 +12,8 @@ See doc/  for user documentation.
 
 documentation here is developer documentation.
 """
+from typing import Callable, Dict
+
 import ctypes
 from ctypes.util import find_library
 
@@ -487,6 +489,10 @@ def show_cache(print_out=True):
     else:
         return out
 
+
+_clear_cache_callbacks: Dict[int, Callable[[], None]] = {}
+
+
 def clear_cache():
     """
     Clears global caches of Epics CA connections, and fully
@@ -502,11 +508,16 @@ def clear_cache():
     used after because underlaying Epics CA connections are cleared here.
     Failing to follow these rules may cause your application to experience
     a random SIGSEGV from inside Epics binaries.
+
+    Use `register_clear_cache()` to register a function which will be
+    called before Epics CA connections are cleared.
+
+    This function is not thread safe.
     """
-    # Clear the cache of PVs used by epics.caget()-like functions
-    # before clear channels references from the cache.
-    from . import pv
-    pv.clear_pvcache()
+    # Clear any cache of CA users so there are not references
+    # to the Epics CA connections which are to be cleared next.
+    for clear_other_cache in _clear_cache_callbacks.values():
+        clear_other_cache()
 
     # Unregister callbacks (if any)
     for chid, entry in list(_chid_cache.items()):
@@ -523,6 +534,27 @@ def clear_cache():
     # in systems with proper fork() implementations
     detach_context()
     create_context()
+
+
+def register_clear_cache(callback: Callable[[], None]):
+    """
+    Register a function which is to be called right before
+    the Epics CA connections are removed. The purpose of the callback
+    is to disconnect from Epics CA connections created through `ca.py`
+    before they are cleared. Im summary, the function should:
+    * Remove any reference to any Epics CA connection created
+      through `ca.py`.
+    * Remove any subscription fom any Epics CA connection created
+      through `ca.py`.
+
+    Failing to do so may result into a random SIGSEGV after using
+    `ca.clear_cache`.
+    """
+    global _clear_cache_callbacks
+    if callable(callback):
+        _clear_cache_callbacks[id(callback)] = callback
+    elif callback is not None:
+        raise RuntimeError(f"Cannot register type {type(callback)}. Callable required.")
 
 
 ## decorator functions for ca functionality:

--- a/epics/ca.py
+++ b/epics/ca.py
@@ -494,6 +494,16 @@ def clear_cache():
     multiprocessing (and is done internally by CAProcess),
     but can be useful to fully reset a Channel Access session.
     """
+    # Clear the cache of PVs used by epics.caget()-like functions
+    # by disconnecting PVs so that all subscriptions are released
+    # prior clearing channels.
+    from . import pv
+    pv_cache = pv._PVcache_
+    pv._PVcache_ = {}
+    for pv in pv_cache.values():
+        pv.disconnect()
+    pv_cache.clear()
+
     # Unregister callbacks (if any)
     for chid, entry in list(_chid_cache.items()):
         try:
@@ -504,10 +514,6 @@ def clear_cache():
     # Clear global state variables
     _cache.clear()
     _chid_cache.clear()
-
-    # Clear the cache of PVs used by epics.caget()-like functions
-    from . import pv
-    pv._PVcache_ = {}
 
     # The old context is copied directly from the old process
     # in systems with proper fork() implementations

--- a/epics/pv.py
+++ b/epics/pv.py
@@ -168,6 +168,22 @@ def fmt_time(tstamp=None):
                          round(1.e5*frac))
 
 
+def clear_pvcache():
+    """Clear an internal cache containing instances of the class `PV`
+    retrieved through `get_pv()`. This is used by `ca*()` functions
+    such as `caget()`.
+    Any instance found in the cache is disconnected.
+    However, the underlaying cache (of `ca`) is kept intact.
+    Use `ca.clear_cache()` to release remaining resources for proper clean-up.
+    """
+    global _PVcache_
+    pv_cache = _PVcache_
+    _PVcache_ = {}
+    for pv in pv_cache.values():
+        pv.disconnect()
+    pv_cache.clear()
+
+
 class PV():
     """Epics Process Variable
 

--- a/epics/pv.py
+++ b/epics/pv.py
@@ -1120,6 +1120,11 @@ class PV():
         it from _PVcache_, so that subsequent connection to this PV will almost
         always make a completely new connection.
 
+        However, this method keeps the EPICS channel ID alive
+        so that it can be re-used later. This may block some resources.
+        Use `ca.clear_channel()` to clear the channel ID if needed
+        only after disconnecting the PV.
+
         Arguments
         -----------
         deepclean, bool  removal all cache connection and access-rights callbacks [True]

--- a/epics/pv.py
+++ b/epics/pv.py
@@ -174,7 +174,9 @@ def clear_pvcache():
     such as `caget()`.
     Any instance found in the cache is disconnected.
     However, the underlaying cache (of `ca`) is kept intact.
-    Use `ca.clear_cache()` to release remaining resources for proper clean-up.
+    This function will be called by `ca.clear_cache()` automatically.
+
+    This function is not thread safe.
     """
     global _PVcache_
     pv_cache = _PVcache_
@@ -182,6 +184,9 @@ def clear_pvcache():
     for pv in pv_cache.values():
         pv.disconnect()
     pv_cache.clear()
+
+
+ca.register_clear_cache(clear_pvcache)
 
 
 class PV():

--- a/epics/pv.py
+++ b/epics/pv.py
@@ -1136,10 +1136,10 @@ class PV():
         it from _PVcache_, so that subsequent connection to this PV will almost
         always make a completely new connection.
 
-        However, this method keeps the EPICS channel ID alive
+        However, this method keeps corresponding Epics CA connection intact
         so that it can be re-used later. This may block some resources.
-        Use `ca.clear_channel()` to clear the channel ID if needed
-        only after disconnecting the PV.
+        Use `ca.clear_channel()` to clear Epics CA connection if needed.
+        Use it only after disconnecting the PV.
 
         Arguments
         -----------

--- a/tests/test_ca_clearcache.py
+++ b/tests/test_ca_clearcache.py
@@ -1,9 +1,8 @@
 import epics
-from epics import ca
+import epics.ca
+import epics.pv
 
-import os
 import time
-import sys
 import subprocess
 import pvnames
 enabledpv = pvnames.clear_cache_enabled
@@ -24,7 +23,22 @@ def run():
         assert value is not None, \
             "PV {} is offline".format(beaconpv)
     time.sleep(0.2)
-    ca.clear_cache()
+    epics.ca.clear_cache()
+
+
+def test_use_monitor():
+    # This test verifies that clear_cache clears subscriptions created by
+    # use_monitor=True prior clearing channels.
+    # Otherwise, EPICS will crash on an attempt to clear subscription
+    # on a cleared channel.
+    assert epics.caget(enabledpv, use_monitor=True) is not None, \
+        "PV {} is offline".format(enabledpv)
+
+    pv = epics.pv.get_pv(enabledpv)
+
+    epics.ca.clear_cache()
+
+    pv.disconnect()
 
 
 def test_subscribe():


### PR DESCRIPTION
Closes #247 

This update prevents a random crash (SIGSEGV) after using ca.clear_cache. This crash is caused by calling ca_clear_subscription (done in pv.PV.disconnect when a monitor is used) any time after ca_clear_channel (done in ca.clear_cache) on the same channel. The randomness is caused by CG because pv.PV.disconnect is called from pv.PV.__del__. This update resolves the problem by disconnecting all PVs found in the PV cache prior clearing all channels.
