### PR TITLE
Added pull-request to the list of events which trigger a workflow

### DIFF
--- a/.github/workflows/test-with-conda.yml
+++ b/.github/workflows/test-with-conda.yml
@@ -1,6 +1,8 @@
 name: Test with Conda, Py3.7 to 3.11
 
-on: [push]
+on:
+  push:
+  pull_request:
 
 jobs:
   build-linux:

--- a/.github/workflows/test-with-conda.yml
+++ b/.github/workflows/test-with-conda.yml
@@ -6,6 +6,9 @@ on:
 
 jobs:
   build-linux:
+    if: >
+      github.event_name == 'push'
+      || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork)
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 5


### PR DESCRIPTION
Closes #249

Enable workflow execution on pull request (open, synchronization, reopen). This makes results of the test visible even for pull-requests from a forked repository. Without this, the results are visible only at the forked repository.