### PR TITLE
Alarm.__repr__ references pv.name instead of pv.pvname

### DIFF
--- a/epics/alarm.py
+++ b/epics/alarm.py
@@ -117,7 +117,7 @@ class Alarm(object):
         self.check_alarm()
 
     def __repr__(self):
-        return "<Alarm '%s', comp=%s, trip_point=%s >" % (self.pv.name,
+        return "<Alarm '%s', comp=%s, trip_point=%s >" % (self.pv.pvname,
                                                           self.comp_name,
                                                           self.trip_point)
     def reset(self):


### PR DESCRIPTION
## Description
Currently printing an `Alarm` object does not work since its `__repr__` references `pv.name` instead of `pv.pvname`.