### PR TITLE
fixes to gh actions workflow, using mamba and CONDA_PREFIX to specify Python version

### DIFF
--- a/.github/workflows/test-python38.yml
+++ b/.github/workflows/test-python38.yml
@@ -1,4 +1,4 @@
-name: Test with Conda, Py3.9 to 3.12
+name: Test with Conda, Py3.8
 
 on: [push]
 
@@ -9,7 +9,7 @@ jobs:
       max-parallel: 5
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8"]
     defaults:
       run:
         shell: bash -l {0}

--- a/tests/Setup/start_ioc.sh
+++ b/tests/Setup/start_ioc.sh
@@ -12,10 +12,10 @@ export EPICS_CA_MAX_ARRAY_BYTES=20100300
 export EPICS_HOST_ARCH=linux-x86_64
 
 if [ -z ${EPICS_BASE+x} ] ; then
-    if [ -z ${CONDA+x} ] ; then
+    if [ -z ${CONDA_PREFIX+x} ] ; then
         EPICS_BASE=/usr/local/epics/base
     else
-        EPICS_BASE=$CONDA/epics
+        EPICS_BASE=$CONDA_PREFIX/epics
     fi
 fi
 


### PR DESCRIPTION

## Description

This fixes the GitHub Actions workflow scripts to specify the Python version correctly for testing.   

The key change is to use mamba consistently to install Anaconda packages. 

This PR illustrates that the master branch fails with Python 3.8 as noted in #266 and proposed to be fixed in #267. 


