### PR TITLE
Fixes an issue where background color of wx epics widgets with the PMixin couldn't be set

### DIFF
--- a/epics/wx/wxlib.py
+++ b/epics/wx/wxlib.py
@@ -281,7 +281,7 @@ class PVCtrlMixin(PVMixin):
             if fg   is not None:
                 self.SetForegroundColour(fg)
             if bg   is not None:
-                self.SetBackgroundColour(fg)
+                self.SetBackgroundColour(bg)
         except:
             pass
         self._connect_bgcol = self.GetBackgroundColour()


### PR DESCRIPTION
As title. There was a typo in the wx epics widgets PVMixin that prevented the background color from being set.