### PR TITLE
Autosave fix

### DIFF
--- a/epics/autosave/save_restore.py
+++ b/epics/autosave/save_restore.py
@@ -29,6 +29,7 @@ import sys
 import os
 import datetime
 import json
+import time
 from epics.pv import get_pv
 from epics.utils import IOENCODING
 
@@ -61,6 +62,8 @@ def restore_pvs(filepath, debug=False):
     for thispv, value in pv_vals:
         thispv.connect()
         pvname = thispv.pvname
+        if not thispv.connected:
+            time.sleep(0.1)
         if not thispv.connected:
             print("Cannot connect to %s" % (pvname))
         elif not thispv.write_access:

--- a/epics/motor.py
+++ b/epics/motor.py
@@ -527,8 +527,7 @@ class Motor(device.Device):
          """
 
         # Put the motor in "SET" mode
-        self.put('SET', 1)
-
+        self.put('SET', 1, wait=True)
         # determine which drive value to use
         drv = 'VAL'
         if dial:
@@ -536,7 +535,7 @@ class Motor(device.Device):
         elif step or raw:
             drv = 'RVAL'
 
-        self.put(drv, position)
+        self.put(drv, position, wait=True)
 
         # Put the motor back in "Use" mode
         self.put('SET', 0)


### PR DESCRIPTION
This has two fixes. The first is a straightforward fix that fixes an issue with the motor position not being set correctly for a Motor device when using set_position. This was occurring for the Slit pseudomotor in the Optics synApps package, but might occur for other pseudomotors.

The second is a probably not great fix for an issue where the first time I try to restore values to a set of PVs, it often seems to give a not connected error for one or two of them (out of the ~70 that are being restored), something like: Cannot connect to "18ID_DMC_E03:18.DIR". I've done a bit of debugging, and this seems to just be a timing issue. if I add a 0.1 s sleep after trying to connect, the PVs always (well, within my limited testing) read as connected. I'm assuming it has something to do with how the internal mechanism for connecting PVs works, and maybe some race condition if that's done in a thread, so the value of .connected isn't updated by the time the restore_pvs function checks it.

Obviously, adding in a sleep isn't ideal. If it is a race condition then that could fail depending on the computer/etc. involved.

I don't know the internals of how the PVs connect well enough to figure this out easily. I'm hoping maybe you might be able to take a look and fix it pretty easily?

This is particularly around lines 61-65 in the save_restore.py file. I found that if I add two lines to make it work like this:
for thispv, value in pv_vals:
    thispv.connect()
    pvname = thispv.pvname
    if not thispv.connected:
        time.sleep(0.1)
    if not thispv.connected:
        ....

where that first "if not thispv.connected" with the sleep is what I've added, that seems to work. But there's got to be a better way to do it, right?