### PR TITLE
Charset normalizer as fallback option

### DIFF
--- a/epics/utils.py
+++ b/epics/utils.py
@@ -4,6 +4,11 @@ String and data utils
 import sys
 import os
 
+try:
+    from charset_normalizer import from_bytes
+except ImportError:
+    from_bytes = None
+
 IOENCODING =  os.environ.get('PYEPICS_ENCODING',
               os.environ.get('PYTHONIOENCODING',
                              'utf-8'))
@@ -18,8 +23,13 @@ def bytes2str(st1):
     'byte to string conversion'
     if isinstance(st1, str):
         return st1
-    elif isinstance(st1, bytes):
-        return str(st1, IOENCODING)
+    if isinstance(st1, bytes):
+        try:
+            return str(st1, IOENCODING)
+        except UnicodeDecodeError:
+            if from_bytes is None:
+                raise
+            return str(from_bytes(st1).best())
     else:
         return str(st1)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -80,6 +80,7 @@ test =
     pytest
     pytest-cov
     psutil; platform_system=="Linux"
+    charset-normalizer
 all =
     %(test)s
     %(doc)s

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,42 @@
+from unittest import mock
+
+import pytest
+
+from epics.utils import bytes2str
+
+
+@pytest.mark.parametrize(
+    "input_bytes, expected_str, raises_exc",
+    [
+        (b"hello", "hello", False),
+        ("hello", "hello", False),
+        ("°".encode("latin1"), "°", True),
+        ("°".encode("utf-8"), "°", False),
+        (1, 1, False),
+    ],
+)
+def test_bytes2str_without_charset_normalizer(input_bytes, expected_str, raises_exc):
+    with mock.patch("epics.utils.from_bytes", None):
+        if raises_exc:
+            with pytest.raises(UnicodeDecodeError):
+                bytes2str(input_bytes)
+        else:
+            assert bytes2str(input_bytes) == expected_str
+
+
+@pytest.mark.parametrize(
+    "input_bytes, expected_str, raises_exc",
+    [
+        (b"hello", "hello", False),
+        ("hello", "hello", False),
+        ("°".encode("latin1"), "ﺍ", False),  # latin1 decoding doesn't work but it doesn't raise
+        ("°".encode("utf-8"), "°", False),
+        (1, "1", False),
+    ],
+)
+def test_bytes2str_with_charset_normalizer(input_bytes, expected_str, raises_exc):
+    if raises_exc:
+        with pytest.raises(UnicodeDecodeError):
+            bytes2str(input_bytes)
+    else:
+        assert bytes2str(input_bytes) == expected_str


### PR DESCRIPTION
## Description

When dealing with inconsistent encodings, setting the environment variable may not be sufficient. This PR adds the charset_normalizer as fallback option if the specified encoding fails. 
While there is no guarantee that is decodes correctly (cf. tests), it at least prevents decoding errors. 

closes #278 
