### PR TITLE
fix: use set_parse_action instead of setParseAction

### DIFF
--- a/epics/autosave/save_restore.py
+++ b/epics/autosave/save_restore.py
@@ -186,7 +186,7 @@ number = Word(nums)
 integer = Combine( Optional(minus) + number )
 float_number = Combine( integer +
                         Optional( point + Optional(number) )
-                        ).setParseAction(lambda t:float(t[0]))
+                        ).set_parse_action(lambda t:float(t[0]))
 
 # PV names according to app developer guide and tech-talk email thread at:
 # https://epics.anl.gov/tech-talk/2019/msg01429.php


### PR DESCRIPTION
## Description

`pyparsing` deprecated `setParseAction` in favor of `set_parse_action`. 

It looks to me as if these two methods are the same, see  https://github.com/pyparsing/pyparsing/blob/4f52ba7e9daa4845fd94dd4a1999fc42204207fe/pyparsing/core.py#L2604


